### PR TITLE
Remove default values for k and threshold parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,13 @@
+0.7.1
+-----
+Removed the default values for the threshold and "top k results" parameters
+throughout as these parameters should always be determined by the requirements
+at the call site. This modifies the API of the functions
+`entitymatch.{*filter_similarity*,calculate_mapping_greedy}`,
+`distributed_processing.calculate_filter_similarity` and
+`network_flow.map_entities` by requiring the values of `k` and `threshold` to
+be specified in every case.
+
 0.7.0
 -----
 

--- a/anonlink/benchmark.py
+++ b/anonlink/benchmark.py
@@ -70,7 +70,7 @@ def compute_comparison_speed(n1, n2, threshold):
     filters2 = [some_filters[random.randrange(2000, 10000)] for _ in range(n2)]
 
     start = timer()
-    sparse_matrix = calculate_filter_similarity(filters1, filters2, k=len(filters2), threshold=threshold)
+    sparse_matrix = calculate_filter_similarity(filters1, filters2, len(filters2), threshold)
     t1 = timer()
     res = greedy_solver(sparse_matrix)
     end = timer()

--- a/anonlink/distributed_processing.py
+++ b/anonlink/distributed_processing.py
@@ -10,8 +10,7 @@ from anonlink.util import chunks
 
 
 def calc_chunk_result(chunk_number, chunk, filters2, k, threshold):
-    chunk_results = anonlink.entitymatch.calculate_filter_similarity(chunk, filters2,
-                                                                     k=k, threshold=threshold)
+    chunk_results = anonlink.entitymatch.calculate_filter_similarity(chunk, filters2, k, threshold)
 
     partial_sparse_result = []
     # offset chunk's A index by chunk_size * chunk_number
@@ -23,7 +22,7 @@ def calc_chunk_result(chunk_number, chunk, filters2, k, threshold):
     return partial_sparse_result
 
 
-def calculate_filter_similarity(filters1, filters2, k=10, threshold=0.5):
+def calculate_filter_similarity(filters1, filters2, k, threshold):
     """
     Example way of computing similarity scores in parallel.
 

--- a/anonlink/entitymatch.py
+++ b/anonlink/entitymatch.py
@@ -118,7 +118,7 @@ def greedy_solver(sparse_similarity_matrix):
     return mappings
 
 
-def calculate_mapping_greedy(filters1, filters2, threshold=0.95, k=5):
+def calculate_mapping_greedy(filters1, filters2, threshold, k):
     """
     Brute-force one-shot solver.
 
@@ -136,7 +136,7 @@ def calculate_mapping_greedy(filters1, filters2, threshold=0.95, k=5):
     return greedy_solver(sparse_matrix)
 
 
-def calculate_filter_similarity(filters1, filters2, k=10, threshold=0.5, use_python=False):
+def calculate_filter_similarity(filters1, filters2, k, threshold, use_python=False):
     """Computes a sparse similarity matrix with:
         - size no larger than k * len(filters1)
         - order of len(filters1) + len(filters2)
@@ -169,5 +169,5 @@ def calculate_filter_similarity(filters1, filters2, k=10, threshold=0.5, use_pyt
     if use_python:
         return python_filter_similarity(filters1, filters2)
     else:
-        return cffi_filter_similarity_k(filters1, filters2, k=k, threshold=threshold)
+        return cffi_filter_similarity_k(filters1, filters2, k, threshold)
 

--- a/anonlink/network_flow.py
+++ b/anonlink/network_flow.py
@@ -110,7 +110,7 @@ def calculate_entity_mapping(G, method=None):
     return entity_map
 
 
-def map_entities(weights, threshold=0.8, method=None):
+def map_entities(weights, threshold, method=None):
     """Calculate a dictionary mapping using similarity scores.
 
     :param weights: The list of tuples including n-gram similarity scores

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
 
 setup(
     name="anonlink",
-    version='0.7.0',
+    version='0.7.1',
     description='Anonymous linkage using cryptographic hashes and bloom filters',
     url='https://github.com/n1analytics/anonlink',
     license='Apache',

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -44,23 +44,32 @@ class EntityHelperMixin(object):
 
 
 class EntityHelperTestMixin(EntityHelperMixin):
+    default_similarity_k = 10
+    default_similarity_threshold = 0.5
+    default_greedy_k = 5
+    default_greedy_threshold = 0.95
+
     def test_default(self):
-        similarity = entitymatch.calculate_filter_similarity(self.filters1, self.filters2)
+        similarity = entitymatch.calculate_filter_similarity(
+            self.filters1, self.filters2, self.default_similarity_k, self.default_similarity_threshold)
         mapping = network_flow.map_entities(similarity, threshold=0.95)
         self.check_accuracy(mapping)
 
     def test_bipartite(self):
-        similarity = entitymatch.calculate_filter_similarity(self.filters1, self.filters2)
+        similarity = entitymatch.calculate_filter_similarity(
+            self.filters1, self.filters2, self.default_similarity_k, self.default_similarity_threshold)
         mapping = network_flow.map_entities(similarity, threshold=0.95, method='bipartite')
         self.check_accuracy(mapping)
 
     def test_weighted(self):
-        similarity = entitymatch.calculate_filter_similarity(self.filters1, self.filters2)
+        similarity = entitymatch.calculate_filter_similarity(
+            self.filters1, self.filters2, self.default_similarity_k, self.default_similarity_threshold)
         mapping = network_flow.map_entities(similarity, threshold=0.95, method='weighted')
         self.check_accuracy(mapping)
 
     def test_greedy(self):
-        mapping = entitymatch.calculate_mapping_greedy(self.filters1, self.filters2)
+        mapping = entitymatch.calculate_mapping_greedy(
+            self.filters1, self.filters2, self.default_greedy_threshold, self.default_greedy_k)
         self.check_accuracy(mapping)
 
 
@@ -93,7 +102,8 @@ class TestEntityMatchingE2E_100(EntityHelperTestMixin, unittest.TestCase):
 
         self.filters2[-2] = (b, 101, b.count())
 
-        sparse_scores = entitymatch.calculate_filter_similarity(self.filters1, self.filters2, k=20, threshold=0.8, use_python=False)
+        sparse_scores = entitymatch.calculate_filter_similarity(
+            self.filters1, self.filters2, k=20, threshold=0.8, use_python=False)
         ordered_by_score = sorted(sparse_scores, key=itemgetter(1), reverse=True)
 
         ordered_scores = sorted(ordered_by_score, key=itemgetter(0))
@@ -124,7 +134,8 @@ class TestEntityMatchingE2E_10k(EntityHelperMixin, unittest.TestCase):
         self.s1, self.s2, self.filters1, self.filters2 = generate_data(self.sample, self.proportion)
 
     def test_greedy(self):
-        mapping = entitymatch.calculate_mapping_greedy(self.filters1, self.filters2)
+        mapping = entitymatch.calculate_mapping_greedy(
+            self.filters1, self.filters2, self.default_greedy_threshold, self.default_greedy_k)
         self.check_accuracy(mapping)
 
 
@@ -139,7 +150,8 @@ class TestEntityMatchingE2E_100k(EntityHelperMixin, unittest.TestCase):
         self.s1, self.s2, self.filters1, self.filters2 = generate_data(self.sample, self.proportion)
 
     def test_greedy(self):
-        mapping = entitymatch.calculate_mapping_greedy(self.filters1, self.filters2)
+        mapping = entitymatch.calculate_mapping_greedy(
+            self.filters1, self.filters2, self.default_greedy_threshold, self.default_greedy_k)
         self.check_accuracy(mapping)
 
 
@@ -154,7 +166,7 @@ class TestEntityMatchTopK(unittest.TestCase):
 
         threshold = 0.8
         similarity = entitymatch.cffi_filter_similarity_k(f1, f2, 4, threshold)
-        mapping = network_flow.map_entities(similarity, threshold=threshold, method=None)
+        mapping = network_flow.map_entities(similarity, threshold, method=None)
 
         for indexA in mapping:
             self.assertEqual(s1[indexA], s2[mapping[indexA]])
@@ -169,26 +181,30 @@ class TestEntityMatchTopK(unittest.TestCase):
 
         threshold = 0.8
         similarity = distributed_processing.calculate_filter_similarity(f1, f2, 4, threshold)
-        mapping = network_flow.map_entities(similarity, threshold=threshold, method=None)
+        mapping = network_flow.map_entities(similarity, threshold, method=None)
 
         for indexA in mapping:
             self.assertEqual(s1[indexA], s2[mapping[indexA]])
 
 
 class TestGreedy(unittest.TestCase):
+    default_greedy_k = 5
+    default_greedy_threshold = 0.95
 
     some_filters = generate_clks(1000)
 
     def test_greedy_matching_works(self):
         filters1 = [self.some_filters[random.randrange(0, 800)] for _ in range(1000)]
         filters2 = [self.some_filters[random.randrange(200, 1000)] for _ in range(1500)]
-        result = entitymatch.calculate_mapping_greedy(filters1, filters2)
+        result = entitymatch.calculate_mapping_greedy(
+            filters1, filters2, self.default_greedy_threshold, self.default_greedy_k)
 
     def test_greedy_chunked_matching_works(self):
         filters1 = [self.some_filters[random.randrange(0, 800)] for _ in range(1000)]
         filters2 = [self.some_filters[random.randrange(200, 1000)] for _ in range(1500)]
 
-        all_in_one_mapping = entitymatch.calculate_mapping_greedy(filters1, filters2, threshold=0.95, k=5)
+        all_in_one_mapping = entitymatch.calculate_mapping_greedy(
+            filters1, filters2, self.default_greedy_threshold, self.default_greedy_k)
 
         filters1_chunk1, filters1_chunk2 = filters1[:500],  filters1[500:]
         assert len(filters1_chunk1) == 500

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -27,6 +27,11 @@ def generate_data(samples, proportion=0.75):
 
 class EntityHelperMixin(object):
 
+    default_similarity_k = 10
+    default_similarity_threshold = 0.5
+    default_greedy_k = 5
+    default_greedy_threshold = 0.95
+
     def check_accuracy(self, mapping):
         # Assert that there are no false matches
         for indx1 in mapping:
@@ -44,10 +49,6 @@ class EntityHelperMixin(object):
 
 
 class EntityHelperTestMixin(EntityHelperMixin):
-    default_similarity_k = 10
-    default_similarity_threshold = 0.5
-    default_greedy_k = 5
-    default_greedy_threshold = 0.95
 
     def test_default(self):
         similarity = entitymatch.calculate_filter_similarity(

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -22,6 +22,9 @@ class TestBloomFilterComparison(unittest.TestCase):
         cls.filters1 = bloomfilter.calculate_bloom_filters(s1, schema.get_schema_types(nl.schema), keys)
         cls.filters2 = bloomfilter.calculate_bloom_filters(s2, schema.get_schema_types(nl.schema), keys)
 
+        cls.default_k = 10
+        cls.default_threshold = 0.5
+
     def _check_proportion(self, similarity):
         exact_matches = 0.0
         for (idx1, score, idx2) in similarity:
@@ -55,7 +58,8 @@ class TestBloomFilterComparison(unittest.TestCase):
         self._check_proportion(similarity)
 
     def test_default(self):
-        similarity = entitymatch.calculate_filter_similarity(self.filters1, self.filters2)
+        similarity = entitymatch.calculate_filter_similarity(
+            self.filters1, self.filters2, self.default_k, self.default_threshold)
         self._check_proportion(similarity)
 
     def test_same_score(self):
@@ -66,19 +70,25 @@ class TestBloomFilterComparison(unittest.TestCase):
 
     def test_empty_input_a(self):
         with self.assertRaises(ValueError):
-            entitymatch.calculate_filter_similarity([], self.filters2)
+            entitymatch.calculate_filter_similarity(
+                [], self.filters2, self.default_k, self.default_threshold)
 
     def test_empty_input_b(self):
         with self.assertRaises(ValueError):
-            entitymatch.calculate_filter_similarity(self.filters1, [])
+            entitymatch.calculate_filter_similarity(
+                self.filters1, [], self.default_k, self.default_threshold)
 
     def test_small_input_a(self):
-        similarity = entitymatch.calculate_filter_similarity(self.filters1[:10], self.filters2, use_python=True)
-        similarity = entitymatch.calculate_filter_similarity(self.filters1[:10], self.filters2, use_python=False)
+        similarity = entitymatch.calculate_filter_similarity(
+            self.filters1[:10], self.filters2, self.default_k, self.default_threshold, use_python=True)
+        similarity = entitymatch.calculate_filter_similarity(
+            self.filters1[:10], self.filters2, self.default_k, self.default_threshold, use_python=False)
 
     def test_small_input_b(self):
-        similarity = entitymatch.calculate_filter_similarity(self.filters1, self.filters2[:10], use_python=True)
-        similarity = entitymatch.calculate_filter_similarity(self.filters1, self.filters2[:10], use_python=False)
+        similarity = entitymatch.calculate_filter_similarity(
+            self.filters1, self.filters2[:10], self.default_k, self.default_threshold, use_python=True)
+        similarity = entitymatch.calculate_filter_similarity(
+            self.filters1, self.filters2[:10], self.default_k, self.default_threshold, use_python=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Like it says on the packet. Technically this is API-breaking, since several functions now require four parameters where previously two or three sufficed.

Resolves #80.