### PR TITLE
Fix greedy solver

### DIFF
--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -506,15 +506,17 @@ extern "C"
             }
         }
 
-        int i = 0;
-        while ( ! top_k_scores.empty()) {
+        // Copy the scores and indices in reverse order so that the
+        // best match is at index 0 and the worst is at index
+        // top_k_scores.size()-1.
+        int nscores = top_k_scores.size();
+        for (int i = top_k_scores.size() - 1; i >= 0; --i) {
            scores[i] = top_k_scores.top().score;
            indices[i] = top_k_scores.top().index;
            // Popping the top element is O(log(k))!
            top_k_scores.pop();
-           i += 1;
         }
-
-        return i;
+        assert(top_k_scores.empty());
+        return nscores;
     }
 }

--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -262,7 +262,7 @@ public:
 
 struct score_cmp {
     bool operator()(const Node& a, const Node& b) const {
-        return a.score > b.score;
+        return a.score >= b.score;
     }
 };
 

--- a/anonlink/entitymatch.py
+++ b/anonlink/entitymatch.py
@@ -30,12 +30,7 @@ def python_filter_similarity(filters1, filters2, k, threshold):
         coeffs = filter(lambda c: c[1] >= threshold,
                         enumerate(map(dicecoeff, filters2)))
         top_k = sorted(coeffs, key=itemgetter(1), reverse=True)[:k]
-
-        # NB: The 'reversed' call here is a "hack" to get the ordering
-        # of the Python similarity matrix to match the C++ similarity
-        # matrix. Ideally these structural details would be abstracted
-        # away.
-        result.extend([(i, coeff, j) for j, coeff in reversed(top_k)])
+        result.extend([(i, coeff, j) for j, coeff in top_k])
     return result
 
 

--- a/anonlink/entitymatch.py
+++ b/anonlink/entitymatch.py
@@ -112,18 +112,17 @@ def greedy_solver(sparse_similarity_matrix):
 
     :param sparse_similarity_matrix: Iterable of tuples: (indx_a, similarity_score, indx_b)
     """
-    mappings = {}
+    mapping = {}
 
-    # original indicies of filters which have been claimed
-    matched_entries_b = set()
+    # Indices of filters which have been claimed
+    matched = set()
 
-    for result in sparse_similarity_matrix:
-        index_a, score, possible_index_b = result
-        if possible_index_b not in matched_entries_b:
-            mappings[index_a] = possible_index_b
-            matched_entries_b.add(possible_index_b)
+    for i, score, j in sparse_similarity_matrix:
+        if i not in mapping and j not in matched:
+            mapping[i] = j
+            matched.add(j)
 
-    return mappings
+    return mapping
 
 
 def calculate_mapping_greedy(filters1, filters2, k, threshold):

--- a/anonlink/entitymatch.py
+++ b/anonlink/entitymatch.py
@@ -53,7 +53,7 @@ def cffi_filter_similarity_k(filters1, filters2, k, threshold):
     k = min(k, length_f2)
 
     filter_bits = len(filters1[0][0])
-    assert(filter_bits % 64 == 0, 'Filter length must be a multple of 64 bits.')
+    assert filter_bits % 64 == 0, 'Filter length must be a multple of 64 bits.'
     filter_bytes = filter_bits // 8
 
     match_one_against_many_dice_k_top = lib.match_one_against_many_dice_k_top

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -36,13 +36,8 @@ class TestBloomFilterComparison(unittest.TestCase):
 
     def assert_similarity_matrices_equal(self, M, N):
         self.assertEqual(len(M), len(N))
-        for m, n in zip(M, N):
-            self.assertEqual(m[0], n[0])
-            self.assertAlmostEqual(m[1], n[1])
-            ## FIXME: This line frequently triggers issue #78 at the
-            ## call sites below; it should be reenabled when that
-            ## issue is resolved.
-            #self.assertEqual(m[2], n[2])
+        for m in M:
+            self.assertIn(m, N)
 
     def test_cffi_manual(self):
         nl = randomnames.NameList(30)


### PR DESCRIPTION
(i) Minor fix to greedy solver, so that mappings are set by the first match, not repeatedly overwritten. 
(ii) Some related changes to the order that elements are placed in the similarity matrix which ensure the solver has a good chance of picking good matches.

Fixes #82.