### PR TITLE
Fix issue 78

### DIFF
--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -262,7 +262,7 @@ public:
 
 struct score_cmp {
     bool operator()(const Node& a, const Node& b) const {
-        return a.score > b.score;
+        return a.score >= b.score;
     }
 };
 

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -36,13 +36,8 @@ class TestBloomFilterComparison(unittest.TestCase):
 
     def assert_similarity_matrices_equal(self, M, N):
         self.assertEqual(len(M), len(N))
-        for m, n in zip(M, N):
-            self.assertEqual(m[0], n[0])
-            self.assertAlmostEqual(m[1], n[1])
-            ## FIXME: This line frequently triggers issue #78 at the
-            ## call sites below; it should be reenabled when that
-            ## issue is resolved.
-            #self.assertEqual(m[2], n[2])
+        for m in M:
+            assert m in N
 
     def test_cffi_manual(self):
         nl = randomnames.NameList(30)

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -37,7 +37,7 @@ class TestBloomFilterComparison(unittest.TestCase):
     def assert_similarity_matrices_equal(self, M, N):
         self.assertEqual(len(M), len(N))
         for m in M:
-            assert m in N
+            self.assertIn(m, N)
 
     def test_cffi_manual(self):
         nl = randomnames.NameList(30)


### PR DESCRIPTION
_Relies on PR #89._
Fix issue #78 by getting `score_cmp` into ordering tied scores by increasing second index (relies on the [definition the `Compare` type in `std::priority_queue`](http://en.cppreference.com/w/cpp/container/priority_queue)). Also compare similarity matrices without reference to the order in which their elements are stored.