### PR TITLE
Improve speed when we have many candidate matches

### DIFF
--- a/anonlink/entitymatch.py
+++ b/anonlink/entitymatch.py
@@ -1,3 +1,4 @@
+from itertools import repeat
 import logging
 
 from anonlink._entitymatcher import ffi, lib
@@ -98,10 +99,10 @@ def cffi_filter_similarity_k(filters1, filters2, k, threshold):
 
         if matches < 0:
             raise ValueError('Internel error: Bad key length')
-        for j in range(matches):
-            ind = c_indices[j]
-            assert ind < len(filters2)
-            result.append((i, c_scores[j], ind))
+
+        # Take the first `matches` elements of c_scores and c_indices.
+        # Store them along with `i`.
+        result.extend(zip(repeat(i, matches), c_scores, c_indices))
 
     return result
 


### PR DESCRIPTION
Addresses #79. Fix by replacing `for` loop with iterators. Iterators are neat!

Benchmark before:
```
Threshold: 0.5
Size 1 | Size 2 | Comparisons      | Total Time (s)          | Throughput
       |        |        (match %) | (comparisons / matching)|  (1e6 cmp/s)
-------+--------+------------------+-------------------------+-------------
  1000 |   1000 |    1e6  (50.79%) |  0.276  (91.6% /  8.4%) |     3.955
  2000 |   2000 |    4e6  (50.41%) |  1.059  (91.2% /  8.8%) |     4.142
  3000 |   3000 |    9e6  (50.85%) |  2.433  (90.0% / 10.0%) |     4.109
  4000 |   4000 |   16e6  (49.54%) |  4.441  (90.4% /  9.6%) |     3.984
```

Benchmark after:
```
Threshold: 0.5
Size 1 | Size 2 | Comparisons      | Total Time (s)          | Throughput
       |        |        (match %) | (comparisons / matching)|  (1e6 cmp/s)
-------+--------+------------------+-------------------------+-------------
  1000 |   1000 |    1e6  (50.14%) |  0.160  (85.9% / 14.1%) |     7.270
  2000 |   2000 |    4e6  (50.58%) |  0.593  (84.1% / 15.9%) |     8.023
  3000 |   3000 |    9e6  (50.77%) |  1.337  (83.8% / 16.2%) |     8.036
  4000 |   4000 |   16e6  (50.61%) |  2.387  (84.2% / 15.8%) |     7.966
```

This unfortunately doesn’t affect the case where we have few matches.