### PR TITLE
Greedy multiparty solver

### DIFF
--- a/anonlink/solving.py
+++ b/anonlink/solving.py
@@ -1,0 +1,97 @@
+from typing import Dict, Mapping, Sequence, Set, Tuple
+
+import numpy as np
+
+from .typechecking import CandidatePairs
+
+
+def greedy_solve(
+    candidates: CandidatePairs,
+    threshold: float
+) -> Mapping[Tuple[int, int], Set[Tuple[int, int]]]:
+    """ Select matches from candidate pairs using the greedy algorithm.
+
+        We assign each record to exactly one 'group' of records that are
+        pairwise matched together. We iterate over `candidates` in order
+        of decreasing similarity. When we encounter a pair of records
+        (let s be their similarity) that do not already belong to the
+        same group, we merge their groups iff (a) every pair of records
+        is permitted to be matched, and (b) the similarity of every pair
+        of records is above s. The latter requirement is only for
+        tie-breaking: we prefer groups whose minimum pairwise similarity
+        is highest. Any group merge rejected due to requirement (b) will
+        be revisited later with that requirement relaxed.
+
+        :param tuple candidates: Candidates, as returned by
+            `find_candidates`.
+        :param float threshold: The similarity threshold. This is
+            ignored in this implementation.
+        :param bool overwrite_candidates: Discard data in `candidates`.
+            Enabling may improve performance.
+
+        :return: The mapping. A tuple of (dataset index, record index)
+            maps to a set of its matches. Each match is a similar
+            2-tuple.
+    """
+    dset_indices_sseq, rec_indices_sseq, sims_seq = candidates
+    
+    # Sort pairs in decreasing order of similarity
+    sorted_indices = np.argsort(sims_seq)[::-1]
+    dset_indices = np.asarray(dset_indices_sseq)[:,sorted_indices]
+    rec_indices = np.asarray(rec_indices_sseq)[:,sorted_indices]
+
+    assert len(sorted_indices.shape) == 1
+    assert len(dset_indices.shape) == 2
+    assert len(rec_indices.shape) == 2
+    assert dset_indices.shape == rec_indices.shape
+    assert dset_indices.shape[1] == sorted_indices.shape[0]
+    assert rec_indices.shape[1] == sorted_indices.shape[0]
+
+    matches = {}  # type: Dict[Tuple[int, int], Set[Tuple[int,int]]]
+    matchable_pairs = set()
+    for dset_is, rec_is in zip(dset_indices.T, rec_indices.T): 
+        i0, i1 = zip(dset_is, rec_is)
+
+        if i0 in matches and i1 in matches:
+            # Both records are assigned to a group.
+            # Check if mergeable.
+            matchable_pairs.add(frozenset((i0, i1)))
+            if all(frozenset((j0, j1)) in matchable_pairs
+                   for j0 in matches[i0]
+                   for j1 in matches[i1]):
+                # Yes, mergeable.
+                # Minor cleanup.
+                matchable_pairs.difference(frozenset((j0, j1))
+                                             for j0 in matches[i0]
+                                             for j1 in matches[i1])
+                # Merge groups.
+                merged_group = matches[i0]
+                merged_group.update(matches[i1])
+                matches.update((j, merged_group) for j in matches[i1])
+            continue
+
+        if i0 not in matches and i1 in matches:
+            i0, i1 = i1, i0
+            # Symmetry. Fall through.
+        if i0 in matches and i1 not in matches:
+            # i0 is in a group, but i1 isn't.
+            # See if we may assign i1 to that group.
+            matchable_pairs.add(frozenset((i0, i1)))
+            if all(frozenset((j, i1)) in matchable_pairs
+                   for j in matches[i0]):
+                # Yes. We let's do that.
+                # Minor cleanup.
+                matchable_pairs.difference(frozenset((j, i1))
+                                             for j in matches[i0])
+                # Add i1 to i0's group.
+                matches[i0].add(i1)
+                matches[i1] = matches[i0]
+            continue
+
+        if i0 not in matches and i1 not in matches:
+            # Neither is in a group, so let's make a new one.
+            group = {i0, i1}
+            matches[i0] = group
+            matches[i1] = group
+
+    return matches

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -1,0 +1,81 @@
+from anonlink.solving import greedy_solve
+
+def _zip_candidates(candidates):
+    candidates = tuple(candidates)
+    if not candidates:
+        return ((), ()), ((), ()), ()
+    records1, records2, sims = zip(*candidates)
+    dataset_indices = []
+    record_indices = []
+    for (d1, r1), (d2, r2) in zip(records1, records2):
+        dataset_indices.append((d1, d2))
+        record_indices.append((r1, r2))
+    return (tuple(zip(*dataset_indices)),
+            tuple(zip(*record_indices)),
+            sims)
+
+
+def _compare_matching(result, truth):
+    result = frozenset(map(frozenset, result.values()))
+    truth = frozenset(map(frozenset, truth))
+    assert result == truth
+
+
+def test_greedy_twoparty():
+    candidates = [((0, 0), (1, 0), .8)]
+    result = greedy_solve(_zip_candidates(candidates), .5)
+    _compare_matching(result, [{(0,0), (1,0)}])
+
+    candidates = [((0, 0), (1, 0), .8),
+                  ((0, 1), (1, 0), .7)]
+    result = greedy_solve(_zip_candidates(candidates), .5)
+    _compare_matching(result, [{(0,0), (1,0)}])
+    result = greedy_solve(_zip_candidates(reversed(candidates)), .5)
+    _compare_matching(result, [{(0,0), (1,0)}])
+    
+    candidates = []
+    result = greedy_solve(_zip_candidates(candidates), .5)
+    _compare_matching(result, [])
+    
+    candidates = [((0, 0), (1, 0), .8),
+                  ((0, 0), (1, 1), .7),
+                  ((0, 1), (1, 0), .7),
+                  ((0, 1), (1, 1), .6)]
+    result = greedy_solve(_zip_candidates(candidates), .5)
+    _compare_matching(result, [{(0,0), (1,0)},
+                               {(0,1), (1,1)}])
+    result = greedy_solve(_zip_candidates(reversed(candidates)), .5)
+    _compare_matching(result, [{(0,0), (1,0)},
+                               {(0,1), (1,1)}])
+
+
+def test_greedy_threeparty():
+    candidates = [((0, 0), (1, 0), .7),
+                  ((0, 0), (2, 0), .7),
+                  ((1, 0), (2, 0), .9),
+                  ((0, 0), (1, 1), .8),
+                  ((0, 0), (2, 1), .8),
+                  ((1, 1), (2, 1), .8)]
+    result = greedy_solve(_zip_candidates(candidates), .5)
+    _compare_matching(result, [{(0,0), (1,1), (2,1)},
+                               {(1,0), (2,0)}])
+    
+    candidates = [((0, 0), (1, 0), .8),
+                  ((0, 0), (2, 0), .7),
+                  ((0, 1), (1, 1), .7),
+                  ((0, 1), (2, 1), .8),
+                  ((1, 1), (2, 1), .8)]
+    result = greedy_solve(_zip_candidates(candidates), .5)
+    _compare_matching(result, [{(0,0), (1,0)},
+                               {(0,1), (1,1), (2,1)}])
+
+
+def test_greedy_fourparty():
+    candidates = [((0, 0), (1, 0), .9),
+                  ((2, 0), (3, 0), .9),
+                  ((0, 0), (2, 0), .7),
+                  ((1, 0), (3, 0), .7),
+                  ((0, 0), (3, 0), .7),
+                  ((1, 0), (2, 0), .7)]
+    result = greedy_solve(_zip_candidates(candidates), .5)
+    _compare_matching(result, [{(0,0), (1,0), (2,0), (3,0)}])


### PR DESCRIPTION
__Gist of the algorithm__
We assign each record to exactly one group of records that are pairwise matched together. We iterate over the candidate pairs in order of decreasing similarity. When we encounter a pair of records (let _s_ be their similarity) that do not already belong to the same group, we merge their groups iff (a) every pair of records is permitted to be matched, and (b) the similarity of every pair of records is above _s_. The latter requirement is only for tie-breaking: we prefer groups whose minimum pairwise similarity is highest. Any group merge rejected due to requirement (b) will be revisited later with that requirement relaxed.

__In pseudocode__
```python
def _are_mergeable(
    candidate_pairs : Set[UnorderedPair[Record]],
    similarity : Callable[UnorderedPair[Record], float],
    group1 : Set[Record],
    group2 : Set[Record],
    threshold : float
) -> bool:
    for pair in unordered_product(group1, group2):
        if pair not in candidate_pairs:
            # This pair cannot be matched.
            return False
        if similarity(pair) < threshold:
            # This pair is not similar enough.
            return False
    return True

def _merge_groups(
    matches : Dict[Node, Set[Record]],
    group1 : Set[Record],
    group2 : Set[Record]
) -> Dict[Node, Set[Record]]:
    merged_group = group1 | group2
    for record in merged_group:
        matches[record] = merged_group
    return matches

def multiparty_greedy_solver(
    records : Set[Record],
    candidate_pairs : Set[UnorderedPair[Record]],
    similarity : Callable[UnorderedPair[Record], float]
) -> Set[Set[Record]]:
    # Maps each record to the set of its matches.
    # Start with clusters of one. We'll join some of these together.
    matches = {record : {record} for record in records}

    # Iterate over pairs from most to least similar.
    for pair in sorted(candidate_pairs,
                       key=similarity,
                       descending=True):
        record1, record2 = pair
        matches_record1 = matches[record1]
        matches_record2 = matches[record2]

        if record1 in matches_record2:
            # Already matched.
            continue

        merge_threshold = similarty(pair)
        # Merge only if the distance of the farthest points in the
        # groups is <= similarity(pair). This is so we prioritise
        # clusters whose minimum pairwise similarity is highest.
        if _are_mergeable(candidatePairs
                          similarity,
                          matches_record1, matches_record2,
                          merge_threshold):
            matches = _merge_groups(matches,
                                    matches_record1, matches_record2)

    return set(matches.values())
```

The implementation is somewhat different than this pseudocode for efficiency.