### PR TITLE
Optimise greedy multiparty solver

### DIFF
--- a/anonlink/similarities.py
+++ b/anonlink/similarities.py
@@ -3,7 +3,7 @@ import functools
 import heapq
 import itertools
 import operator
-from typing import (cast, Counter, DefaultDict, Dict, Iterable,
+from typing import (cast, DefaultDict, Dict, Iterable,
                     List, Optional, Sequence, Tuple)
 
 import numpy as np
@@ -42,7 +42,7 @@ def _hamming_similarity_k(
         candidates[1][i1].append(c)
             
     # Take the best k candidates for each record and count them
-    pair_counter = collections.Counter()  # type: Counter[Tuple[float, Tuple[int, int]]]
+    pair_counter = collections.Counter()  # type: Dict[Tuple[float, Tuple[int, int]], int]
     for dset_cands in candidates:
         for unfiltered_cands in dset_cands.values():
             pair_counter.update(heapq.nlargest(k, unfiltered_cands))

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -16,8 +16,8 @@ def _zip_candidates(candidates):
 
 
 def _compare_matching(result, truth):
-    result = frozenset(map(frozenset, result.values()))
-    truth = frozenset(map(frozenset, truth))
+    result = set({id(r): frozenset(r) for r in result}.values())
+    truth = set(map(frozenset, truth))
     assert result == truth
 
 


### PR DESCRIPTION
Changes:
1. Use better data structure for storing previously seen candidate pairs
2. Change output type from `Mapping[RecordId, Set[RecordId]]` to `Iterable[Iterable[RecordId]]`, where `RecordId = Tuple[int, int]` contains the dataset index and the record index within the dataset.

Results:
On 5 datasets of about 3250 records each and with 4720053 candidate pairs (so very low threshold), the previous implementation took 245s, whereas this one takes 27s. (This is not all attributable to the changed data structure. There was also a bug that caused unnecessary copying.)