### PR TITLE
Api new serialisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 
 python:
   - '3.6'
-  - '3.7'
+  - '3.7-dev'
   - 'nightly'
   - 'pypy3'
 
@@ -14,6 +14,7 @@ env:
 
 matrix:
   allow_failures:
+    - python: '3.7-dev'
     - python: 'nightly'
     - python: 'pypy3'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 
 python:
   - '3.6'
+  - '3.7'
   - 'nightly'
   - 'pypy3'
 

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -12,7 +12,7 @@ VENV_DIRECTORY = "env"
 GIT_CONTEXT = "jenkins"
 
 def configs = [
-    [label: 'GPU 1', pythons: ['python3.6', 'python3.7'], compilers: ['clang', 'gcc']],
+    [label: 'GPU 1', pythons: ['python3.6'], compilers: ['clang', 'gcc']],
     //[label: 'osx', pythons: ['python3.5'], compilers: ['clang', 'gcc']]
     [label: 'McNode', pythons: ['python3.6', 'python3.7'], compilers: ['clang']]
 ]

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -117,7 +117,7 @@ try {
 node('GPU 1') {
   stage('Release') {
     try {
-      build('python3.7', 'gcc', 'GPU 1', true)
+      build('python3.6', 'gcc', 'GPU 1', true)
       commit.setSuccessStatus(GIT_CONTEXT)
     } catch (Exception e) {
       commit.setFailStatus("Release failed", GIT_CONTEXT);

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -12,9 +12,9 @@ VENV_DIRECTORY = "env"
 GIT_CONTEXT = "jenkins"
 
 def configs = [
-    [label: 'GPU 1', pythons: ['python3.4', 'python3.5', 'python3.6'], compilers: ['clang', 'gcc']],
+    [label: 'GPU 1', pythons: ['python3.6', 'python3.7'], compilers: ['clang', 'gcc']],
     //[label: 'osx', pythons: ['python3.5'], compilers: ['clang', 'gcc']]
-    [label: 'McNode', pythons: ['python3.5'], compilers: ['clang']]
+    [label: 'McNode', pythons: ['python3.6', 'python3.7'], compilers: ['clang']]
 ]
 
 def PythonVirtualEnvironment prepareVirtualEnvironment(String pythonVersion, clkhashPackageName, compiler, venv_directory = VENV_DIRECTORY) {
@@ -117,7 +117,7 @@ try {
 node('GPU 1') {
   stage('Release') {
     try {
-      build('python3.5', 'gcc', 'GPU 1', true)
+      build('python3.7', 'gcc', 'GPU 1', true)
       commit.setSuccessStatus(GIT_CONTEXT)
     } catch (Exception e) {
       commit.setFailStatus("Release failed", GIT_CONTEXT);

--- a/anonlink/serialization.py
+++ b/anonlink/serialization.py
@@ -6,22 +6,31 @@ import typing as _typing
 
 from . import typechecking as _typechecking
 
-
 # FILE FORMAT
-# This is subject to change.
-# The format is composed of a header and a sequence of entries.
-# The header is composed of a version (1 byte) and the format for every
-# candidate pair. This format consists of the number of bytes in every
-# similarity (1 byte), the number of bytes in every dataset index (1
-# byte), and the number in every record index (1 byte). In total, the
-# header is composed of 4 bytes.
-# Every entry is composed of a similarity as a IEEE floating point
-# value, a two datset indices, and two record indices. Their sizes as
-# determined by the header.
-# All integers are unsigned. All values are *little-endian* since
-# anonlink is realistically only ever run on little-endian machines. The
-# number of candidate matchings is not included on purpose: if needed,
-# it can be computed from the length of the file.
+#   This is subject to change.
+#   The format is composed of a header and a sequence of entries. The
+# header specifies the version of the format and the sizes of floating-
+# -point and integer types used in the entries. Every entry is composed
+# of a similarity score, two dataset indices, and two record indices.
+#   The header is composed of a version (1 byte) and the format of the
+# candidate pairs. This format consists of the number of bytes in a
+# similarity (1 byte), the number of bytes in a dataset index (1 byte),
+# and the number in a record index (1 byte). In total, the header is
+# composed of 4 bytes.
+#   An entry is composed of a similarity as a IEEE floating-point value,
+# two dataset indices, and two record indices. Their sizes are
+# determined by the header. For example, if the similarity is an IEEE
+# double-precision floating-point value, the size noted by the header
+# will be 8 [bytes].
+#   All integers are unsigned. All values are *little-endian* since
+# anonlink is realistically only ever run on little-endian machines.
+# (This code will still run on big-endian machines, implicitly
+# performing byteorder conversion.) The number of candidate matchings is
+# not included on purpose: if needed, it can be computed from the length
+# of the file.
+#   Similarity scores are stored as a structure of arrays when in
+# memory, but we serialise them as an array of structures. This makes it
+# much easier to merge two serialised files.
 
 # https://docs.python.org/3/library/struct.html#format-characters
 _STRUCT_UINT_LEN_TO_FMT = {1: 'B', 2: 'H', 4: 'L', 8: 'Q'}
@@ -60,6 +69,8 @@ def _entry_struct(
     except KeyError:
         msg = f'indices of {rec_i_t_size} bytes are not supported'
         raise ValueError(msg) from None
+    # Every entry has: a similarity score, two datset indices, and two
+    # record indices.
     return _struct.Struct(f"<{sim_t}2{dset_i_t}2{rec_i_t}")
     
 

--- a/anonlink/serialization.py
+++ b/anonlink/serialization.py
@@ -96,11 +96,10 @@ def _load_to_iterable(
     f: _typing.BinaryIO
 ) -> _typing.Tuple[_CandidatePairIter, int, int, int]:
     # Make sure that f.read(n) returns exactly n bytes.
-    if isinstance(f, _io.RawIOBase):
-        f = _io.BufferedWriter(f)
-    elif not isinstance(f, _io.BufferedIOBase):
-        msg = 'stream must be instance of BufferedIOBase or RawIOBase'
-        raise ValueError(msg)
+    if not isinstance(f, _io.BufferedIOBase):
+        f = _io.BufferedReader(f)  # type: ignore
+        # Mypy complains that f is not guaranteed to be RawIOBase.
+        # That's true but BufferedReader doesn't explicitly check this.
 
     header_bytes = f.read(_HEADER_STRUCT.size)
     if len(header_bytes) != _HEADER_STRUCT.size:

--- a/anonlink/serialization.py
+++ b/anonlink/serialization.py
@@ -1,0 +1,151 @@
+import array as _array
+import io as _io
+import struct as _struct
+
+# https://docs.python.org/3/library/struct.html#format-characters
+_STRUCT_UINT_LEN_TO_FMT = {1: 'B', 2: 'H', 4: 'L', 8: 'Q'}
+_STRUCT_FLOAT_LEN_TO_FMT = {2: 'e', 4: 'f', 8: 'd'}
+
+# https://docs.python.org/3/library/array.html#module-array
+_ARRAY_UINT_TYPES = 'BIHLQ'
+_ARRAY_FLOAT_TYPES = 'df'
+_ARRAY_UINT_LEN_TO_FMT = {_array.array(t).itemsize: t
+                          for t in _ARRAY_UINT_TYPES}
+_ARRAY_FLOAT_LEN_TO_FMT = {_array.array(t).itemsize: t
+                           for t in _ARRAY_FLOAT_TYPES}
+
+_HEADER_STRUCT = _struct.Struct('<BBBB')
+
+
+def _entry_struct(sim_t_size, dset_i_t_size, rec_i_t_size):
+    try:
+        sim_t = _STRUCT_FLOAT_LEN_TO_FMT[sim_t_size]
+    except KeyError:
+        msg = f'floats of {sim_t_size} bytes are not supported'
+        raise ValueError(msg) from None
+    try:
+        dset_i_t = _STRUCT_UINT_LEN_TO_FMT[dset_i_t_size]
+    except KeyError:
+        msg = f'indices of {dset_i_t_size} bytes are not supported'
+        raise ValueError(msg) from None
+    try:
+        rec_i_t = _STRUCT_UINT_LEN_TO_FMT[rec_i_t_size]
+    except KeyError:
+        msg = f'indices of {rec_i_t_size} bytes are not supported'
+        raise ValueError(msg) from None
+    return _struct.Struct(f"<{sim_t}2{dset_i_t}2{rec_i_t}")
+    
+
+def _dump_from_iterable(
+    f,
+    sim_t_size,
+    dset_i_t_size,
+    rec_i_t_size,
+    iterable):
+    # Fail without writing if the parameters are incorrect.
+    entry_struct = _entry_struct(
+        sim_t_size,
+        dset_i_t_size, rec_i_t_size, recs_per_cand)
+    
+    # Write header. Format: version (1 byte), number of bytes in
+    # similarity (1 byte), number of bytes in dataset index (1 byte),
+    # number of bytes in record index (1 byte). All unsigned. The number
+    # of candidate matchings is not included on purpose: if needed, it
+    # can be computed from the length of the file.
+    f.write(_HEADER_STRUCT.pack(1, sim_t_size, dset_i_t_size, rec_i_t_size))
+    
+    for entry in iterable:
+        f.write(entry_struct.pack(*entry))
+
+
+def _entries_iterable(f, entry_struct):
+    buffer_ = f.read(entry_struct.size)
+    while buffer_:
+        yield entry_struct.unpack(buffer)
+        buffer_ = f.read(entry_struct.size)
+
+
+def _load_to_iterable(f):
+    # Make sure that f.read(n) returns exactly n bytes.
+    if not isinstance(f, _io.BufferedIOBase):
+        f = _io.BufferedWriter(f)
+
+    version, *sizes = _HEADER_STRUCT.unpack(f.read(_HEADER_STRUCT.size))
+    sim_t_size, dset_i_t_size, rec_i_t_size = sizes
+    if version != 1:
+        raise ValueError('unsupported version of serialized file')
+
+    # This may throw if the specified format isn't supported on this
+    # platform.
+    entry_struct = _entry_struct(sim_t_size, dset_i_t_size, rec_i_t_size)
+
+    return (_entries_iterable(f, entry_struct),
+            sim_t_size, dset_i_t_size, rec_i_t_size)
+
+
+def dump_candidate_pairs(f, candidate_pairs):
+    sims, (dset_is0, dset_is1), (rec_is0, rec_is1) = candidate_pairs
+    assert (len(sims)
+            == len(dset_is0) == len(dset_is1)
+            == len(rec_is0) == len(rec_is1))
+    assert sims.itemsize in _ARRAY_FLOAT_TYPES
+    assert all(a.itemsize in _ARRAY_UINT_LEN_TO_FMT
+               for a in dset_is0, dset_is1, rec_is0, rec_is1)
+
+    iterable = zip(sims, dset_is0, dset_is1, rec_is0, rec_is1)
+    sim_t_size = sims.itemsize
+    dset_i_t_size = max(dset_is0.itemsize, dset_is1.itemsize)
+    rec_i_t_size = max(rec_is0.itemsize, rec_is1.itemsize)
+
+    _dump_from_iterable(
+        f, sim_t_size, dset_i_t_size, rec_i_t_size, iterable)
+
+
+def load_candidate_pairs(f):
+    iterable, sim_t_size, dset_i_t_size, rec_i_t_size = _load_to_iterable(f)
+
+    try:
+        sim_t = _ARRAY_FLOAT_LEN_TO_FMT[sim_t_size]
+    except KeyError:
+        msg = f'floats of {sim_t_size} bytes are not supported'
+        raise ValueError(msg) from None
+    try:
+        dset_i_t = _ARRAY_FLOAT_LEN_TO_FMT[dset_i_t_size]
+    except KeyError:
+        msg = f'indices of {dset_i_t_size} bytes are not supported'
+        raise ValueError(msg) from None
+    try:
+        rec_i_t = _ARRAY_FLOAT_LEN_TO_FMT[rec_i_t_size]
+    except KeyError:
+        msg = f'indices of {rec_i_t_size} bytes are not supported'
+        raise ValueError(msg) from None
+    return _struct.Struct(f"<{sim_t}2{dset_i_t}2{rec_i_t}")
+
+    # Future: preallocate memory according to length of file.
+    sims = array(sims_t)
+    dset_is0 = array(dset_i_t)
+    dset_is1 = array(dset_i_t)
+    rec_is0 = array(rec_i_t)
+    rec_is1 = array(rec_i_t)
+    for sim, dset_i0, dset_i1, rec_i0, rec_i1 in iterable:
+        sims.append(sim)
+        dset_is0.append(dset_i0)
+        dset_is1.append(dset_i1)
+        rec_is0.append(rec_i0)
+        rec_is1.append(rec_i1)
+    return sims, (dset_is0, dset_is1), (rec_is0, rec_is1)
+
+
+def merge_serialized_candidate_pairs(f_out, files_in):
+    file_iterables, *sizes = zip(*map(_load_to_iterable, files_in))
+    file_sim_t_size, file_dset_i_t_size, file_rec_i_t_size = sizes
+
+    sim_t_size = max(file_sim_t_size)
+    dset_i_t_size = max(file_dset_i_t_size)
+    rec_i_t_size = max(file_rec_i_t_size)
+    
+    sorted_iterable = heapq.merge(*file_iterables,
+                                  key=lambda x: (-x[0],) + x[1:])
+    _dump_from_iterable(f,
+                        sim_t_size, dset_i_t_size, rec_i_t_size,
+                        sorted_iterable)

--- a/anonlink/serialization.py
+++ b/anonlink/serialization.py
@@ -1,4 +1,5 @@
 import array as _array
+import heapq as _heapq
 import io as _io
 import struct as _struct
 
@@ -17,7 +18,20 @@ _ARRAY_FLOAT_LEN_TO_FMT = {_array.array(t).itemsize: t
 _HEADER_STRUCT = _struct.Struct('<BBBB')
 
 
-def _entry_struct(sim_t_size, dset_i_t_size, rec_i_t_size):
+# This is subject to change.
+# The format is composed of a header and a sequence of entries.
+# The header is composed of:  version (1 byte), number of bytes in
+# similarity (1 byte), number of bytes in dataset index (1 byte), number
+# of bytes in record index (1 byte).
+# Every entry is composed of a similarity as a IEEE floating point
+# value, a two datset indices, and two record indices. Their sizes as
+# determined by the header.
+# All integers are unsigned. All values are *little-endian* (yes, this
+# breaks convention). The number of candidate matchings is not included
+# on purpose: if needed, it can be computed from the length of the file.
+
+
+def _entry_struct(sim_t_size: int, dset_i_t_size: int, rec_i_t_size: int):
     try:
         sim_t = _STRUCT_FLOAT_LEN_TO_FMT[sim_t_size]
     except KeyError:
@@ -44,14 +58,9 @@ def _dump_from_iterable(
     iterable):
     # Fail without writing if the parameters are incorrect.
     entry_struct = _entry_struct(
-        sim_t_size,
-        dset_i_t_size, rec_i_t_size, recs_per_cand)
+        sim_t_size, dset_i_t_size, rec_i_t_size)
     
-    # Write header. Format: version (1 byte), number of bytes in
-    # similarity (1 byte), number of bytes in dataset index (1 byte),
-    # number of bytes in record index (1 byte). All unsigned. The number
-    # of candidate matchings is not included on purpose: if needed, it
-    # can be computed from the length of the file.
+    # Write header.
     f.write(_HEADER_STRUCT.pack(1, sim_t_size, dset_i_t_size, rec_i_t_size))
     
     for entry in iterable:
@@ -59,10 +68,12 @@ def _dump_from_iterable(
 
 
 def _entries_iterable(f, entry_struct):
-    buffer_ = f.read(entry_struct.size)
-    while buffer_:
+    buffer = f.read(entry_struct.size)
+    while buffer:
+        if len(buffer) != entry_struct.size:
+            raise ValueError('ran out of input')
         yield entry_struct.unpack(buffer)
-        buffer_ = f.read(entry_struct.size)
+        buffer = f.read(entry_struct.size)
 
 
 def _load_to_iterable(f):
@@ -70,8 +81,11 @@ def _load_to_iterable(f):
     if not isinstance(f, _io.BufferedIOBase):
         f = _io.BufferedWriter(f)
 
-    version, *sizes = _HEADER_STRUCT.unpack(f.read(_HEADER_STRUCT.size))
-    sim_t_size, dset_i_t_size, rec_i_t_size = sizes
+    header_bytes = f.read(_HEADER_STRUCT.size)
+    if len(header_bytes) != _HEADER_STRUCT.size:
+        raise ValueError('ran out of input')
+    version, sim_t_size, dset_i_t_size, rec_i_t_size = (
+        _HEADER_STRUCT.unpack(header_bytes))
     if version != 1:
         raise ValueError('unsupported version of serialized file')
 
@@ -84,13 +98,19 @@ def _load_to_iterable(f):
 
 
 def dump_candidate_pairs(f, candidate_pairs):
+    """Dump candidate pairs to file.
+
+    :param f: Binary buffer to write to.
+    :param candidate_pairs: Candidate pairs, as returned by a similarity
+        function or `load_candidate_pairs`.
+    """
     sims, (dset_is0, dset_is1), (rec_is0, rec_is1) = candidate_pairs
     assert (len(sims)
             == len(dset_is0) == len(dset_is1)
             == len(rec_is0) == len(rec_is1))
-    assert sims.itemsize in _ARRAY_FLOAT_TYPES
+    assert sims.itemsize in _ARRAY_FLOAT_LEN_TO_FMT
     assert all(a.itemsize in _ARRAY_UINT_LEN_TO_FMT
-               for a in dset_is0, dset_is1, rec_is0, rec_is1)
+               for a in (dset_is0, dset_is1, rec_is0, rec_is1))
 
     iterable = zip(sims, dset_is0, dset_is1, rec_is0, rec_is1)
     sim_t_size = sims.itemsize
@@ -102,6 +122,12 @@ def dump_candidate_pairs(f, candidate_pairs):
 
 
 def load_candidate_pairs(f):
+    """Load candidate pairs from file.
+
+    :param f: Binary buffer to read from.
+    :return: Candidate pairs, compatible with the type returned from a
+        similarity function.
+    """
     iterable, sim_t_size, dset_i_t_size, rec_i_t_size = _load_to_iterable(f)
 
     try:
@@ -110,23 +136,23 @@ def load_candidate_pairs(f):
         msg = f'floats of {sim_t_size} bytes are not supported'
         raise ValueError(msg) from None
     try:
-        dset_i_t = _ARRAY_FLOAT_LEN_TO_FMT[dset_i_t_size]
+        dset_i_t = _ARRAY_UINT_LEN_TO_FMT[dset_i_t_size]
     except KeyError:
         msg = f'indices of {dset_i_t_size} bytes are not supported'
         raise ValueError(msg) from None
     try:
-        rec_i_t = _ARRAY_FLOAT_LEN_TO_FMT[rec_i_t_size]
+        rec_i_t = _ARRAY_UINT_LEN_TO_FMT[rec_i_t_size]
     except KeyError:
         msg = f'indices of {rec_i_t_size} bytes are not supported'
         raise ValueError(msg) from None
-    return _struct.Struct(f"<{sim_t}2{dset_i_t}2{rec_i_t}")
 
-    # Future: preallocate memory according to length of file.
-    sims = array(sims_t)
-    dset_is0 = array(dset_i_t)
-    dset_is1 = array(dset_i_t)
-    rec_is0 = array(rec_i_t)
-    rec_is1 = array(rec_i_t)
+    # Future: preallocate memory according to length of file. This is
+    # not possible in pure Python, but can be done in Cython.
+    sims = _array.array(sim_t)
+    dset_is0 = _array.array(dset_i_t)
+    dset_is1 = _array.array(dset_i_t)
+    rec_is0 = _array.array(rec_i_t)
+    rec_is1 = _array.array(rec_i_t)
     for sim, dset_i0, dset_i1, rec_i0, rec_i1 in iterable:
         sims.append(sim)
         dset_is0.append(dset_i0)
@@ -136,7 +162,24 @@ def load_candidate_pairs(f):
     return sims, (dset_is0, dset_is1), (rec_is0, rec_is1)
 
 
-def merge_serialized_candidate_pairs(f_out, files_in):
+def merge_streams(f_out, files_in):
+    """Merge multiple files with serialised candidate pairs.
+
+    This function preserves the candidate pairs' sorted order. It avoids
+    loading everything into memory.
+
+    The field sizes in the resulting file will be chosen so no
+    information is lost.
+     
+    Note that you cannot simply concatenate two files to obtain a valid
+    candidate pairs dump.
+
+    :param f_out: Binary buffer write the merged candidate pairs to.
+    :param files_in: Sequence of files to read from.
+    """
+    if not files_in:
+        raise ValueError(f'no files provided')
+
     file_iterables, *sizes = zip(*map(_load_to_iterable, files_in))
     file_sim_t_size, file_dset_i_t_size, file_rec_i_t_size = sizes
 
@@ -144,8 +187,8 @@ def merge_serialized_candidate_pairs(f_out, files_in):
     dset_i_t_size = max(file_dset_i_t_size)
     rec_i_t_size = max(file_rec_i_t_size)
     
-    sorted_iterable = heapq.merge(*file_iterables,
-                                  key=lambda x: (-x[0],) + x[1:])
-    _dump_from_iterable(f,
+    sorted_iterable = _heapq.merge(*file_iterables,
+                                   key=lambda x: (-x[0],) + x[1:])
+    _dump_from_iterable(f_out,
                         sim_t_size, dset_i_t_size, rec_i_t_size,
                         sorted_iterable)

--- a/anonlink/typechecking.py
+++ b/anonlink/typechecking.py
@@ -1,16 +1,21 @@
 from array import array
 
 from typing import (Callable, Hashable, Iterable, Mapping,
-                    Optional, Sequence, Set, Tuple)
+                    Optional, Sequence, Set, Tuple, TYPE_CHECKING)
 
 
 Record = Sequence[bool]
 
+if TYPE_CHECKING:
+    FloatArrayType = array[float]
+    IntArrayType = array[int]
+else:
+    FloatArrayType = array
+    IntArrayType = array
 
-
-CandidatePairs = Tuple[array,
-                       Tuple[array, ...],
-                       Tuple[array, ...]]
+CandidatePairs = Tuple[FloatArrayType,
+                       Tuple[IntArrayType, ...],
+                       Tuple[IntArrayType, ...]]
 
 BlockingFunction = Callable[[int, int, Record],
                             Iterable[Hashable]]

--- a/anonlink/typechecking.py
+++ b/anonlink/typechecking.py
@@ -1,12 +1,16 @@
+from array import array
+
 from typing import (Callable, Hashable, Iterable, Mapping,
                     Optional, Sequence, Set, Tuple)
 
 
 Record = Sequence[bool]
 
-CandidatePairs = Tuple[Sequence[Sequence[int]],
-                       Sequence[Sequence[int]],
-                       Sequence[float]]
+
+
+CandidatePairs = Tuple[array,
+                       Tuple[array, ...],
+                       Tuple[array, ...]]
 
 BlockingFunction = Callable[[int, int, Record],
                             Iterable[Hashable]]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -11,9 +11,9 @@ import pytest
 
 from anonlink import serialization
 
-FLOAT_SIZES = (4,) #8)
-UINT_SIZES = (1, )#2, 4, 8)
-CANDIDATE_PAIR_LENGTHS = (#(0, 1, 1000) + (
+FLOAT_SIZES = (4, 8)
+UINT_SIZES = (1, 2, 4, 8)
+CANDIDATE_PAIR_LENGTHS = (0, 1, 1000) + (
     (1000000,)
     if os.environ.get('TEST_SERIALIZATION_BIG', None)
     is not None else ())
@@ -106,9 +106,7 @@ def tmpdir_path(tmpdir_factory):
 
 
 @pytest.fixture(scope='session',
-                params=(
-                    #'file', 
-                    'bytesio',))
+                params=('file', 'bytesio'))
 def new_file_function(request, tmpdir_path):
     if request.param == 'bytesio':
         return io.BytesIO
@@ -241,7 +239,7 @@ class TestLoadCandidatePairs:
 
 
 class TestMergeStreams:
-    @pytest.mark.parametrize('split', (2,))#(1, 2, 5))
+    @pytest.mark.parametrize('split', (1, 2, 5))
     def test_general(self,
                      cands_bytes_pair, new_file_function,
                      split):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,471 @@
+import array
+import contextlib
+import io
+import itertools
+import os
+import random
+import struct
+import uuid
+
+import pytest
+
+from anonlink import serialization
+
+FLOAT_SIZES = (4, 8)
+UINT_SIZES = (1, 2, 4, 8)
+CANDIDATE_PAIR_LENGTHS = (0, 1, 1000) + (
+    (1000000,)
+    if os.environ.get('TEST_SERIALIZATION_BIG', None)
+    is not None else ())
+
+ARRAY_FLOAT_SIZE_TO_FMT = {array.array(t).itemsize: t
+                           for t in 'df'}
+ARRAY_UINT_SIZE_TO_FMT = {array.array(t).itemsize: t
+                          for t in 'BIHLQ'}
+FLOAT_SIZE_TO_STRUCT = {2: struct.Struct('<e'),
+                        4: struct.Struct('<f'),
+                        8: struct.Struct('<d')}
+
+RANDOM_SEED = 3214
+BITS_IN_BYTE = 8
+FORMAT_VERSION = 1
+FORMAT_BYTEORDER = 'little'
+UNSUPPORTED_SIZE = 3  # This may unfortunately be platform-dependent.
+DEFAULT_SIZE = 4  # This may unfortunately be platform-dependent.
+DEFAULT_FILES_NUM = 3
+DEFAULT_LENGTH = 5
+
+
+def random_pairs_list(dset_i_size, rec_i_size, length, seed=RANDOM_SEED):
+    dset_i_range_stop = 2 ** (BITS_IN_BYTE * dset_i_size)
+    rec_i_range_stop = 2 ** (BITS_IN_BYTE * rec_i_size)
+
+    rng = random.Random(seed)
+    random_pairs = []
+    for _ in range(length):
+        sim = rng.uniform(0, 1)
+        dset_i0 = rng.randrange(dset_i_range_stop)
+        dset_i1 = rng.randrange(dset_i_range_stop)
+        rec_i0 = rng.randrange(rec_i_range_stop)
+        rec_i1 = rng.randrange(rec_i_range_stop)
+
+        random_pairs.append((sim, dset_i0, dset_i1, rec_i0, rec_i1))
+    random_pairs.sort(key=lambda x: (-x[0],) + x[1:])
+    return random_pairs
+
+
+def pairs_list_to_candidate_pairs(pairs_list,
+                                  sim_size, dset_i_size, rec_i_size):
+    sims = array.array(ARRAY_FLOAT_SIZE_TO_FMT[sim_size])
+    dset_is0 = array.array(ARRAY_UINT_SIZE_TO_FMT[dset_i_size])
+    dset_is1 = array.array(ARRAY_UINT_SIZE_TO_FMT[dset_i_size])
+    rec_is0 = array.array(ARRAY_UINT_SIZE_TO_FMT[rec_i_size])
+    rec_is1 = array.array(ARRAY_UINT_SIZE_TO_FMT[rec_i_size])
+    for sim, dset_i0, dset_i1, rec_i0, rec_i1 in pairs_list:
+        sims.append(sim)
+        dset_is0.append(dset_i0)
+        dset_is1.append(dset_i1)
+        rec_is0.append(rec_i0)
+        rec_is1.append(rec_i1)
+    return sims, (dset_is0, dset_is1), (rec_is0, rec_is1)
+
+
+def pairs_list_to_bytes(pairs_list, sim_size, dset_i_size, rec_i_size):
+    bytes_ = bytearray((1, sim_size, dset_i_size, rec_i_size))
+    for sim, dset_i0, dset_i1, rec_i0, rec_i1 in pairs_list:
+        bytes_.extend(FLOAT_SIZE_TO_STRUCT[sim_size].pack(sim))
+        bytes_.extend(dset_i0.to_bytes(dset_i_size, FORMAT_BYTEORDER))
+        bytes_.extend(dset_i1.to_bytes(dset_i_size, FORMAT_BYTEORDER))
+        bytes_.extend(rec_i0.to_bytes(rec_i_size, FORMAT_BYTEORDER))
+        bytes_.extend(rec_i1.to_bytes(rec_i_size, FORMAT_BYTEORDER))
+    return bytes_
+
+
+@pytest.fixture(scope='session',
+                params=itertools.product(
+                    FLOAT_SIZES, UINT_SIZES, UINT_SIZES,
+                    CANDIDATE_PAIR_LENGTHS))
+def cands_bytes_pair(request):
+    sim_size, dset_i_size, rec_i_size, length = request.param
+    pairs_list = random_pairs_list(dset_i_size, rec_i_size, length)
+    candidate_pairs = pairs_list_to_candidate_pairs(
+        pairs_list, sim_size, dset_i_size, rec_i_size)
+    bytes_ = pairs_list_to_bytes(pairs_list, sim_size, dset_i_size, rec_i_size)
+    return candidate_pairs, bytes_, pairs_list, request.param
+
+
+@pytest.fixture(scope='session')
+def tmpdir_path(tmpdir_factory):
+    return tmpdir_factory.mktemp('tmpdata')
+
+
+@pytest.fixture(scope='session',
+                params=('file', 'bytesio'))
+def new_file_function(request, tmpdir_path):
+    if request.param == 'bytesio':
+        return io.BytesIO
+    if request.param == 'file':
+        return lambda: open(tmpdir_path.join(str(uuid.uuid4())), 'w+b')
+    raise ValueError('invalid param')
+
+
+class TestDumpCandidatePairs:
+    def test_general(self, cands_bytes_pair, new_file_function):
+        candidate_pairs, bytes_, *_ = cands_bytes_pair
+        with new_file_function() as f:
+            serialization.dump_candidate_pairs(f, candidate_pairs)
+            f.seek(0)
+            assert f.read() == bytes_
+
+
+class TestLoadCandidatePairs:
+    def test_general(self, cands_bytes_pair, new_file_function):
+        candidate_pairs, bytes_, *_ = cands_bytes_pair
+        with new_file_function() as f:
+            f.write(bytes_)
+            f.seek(0)
+            assert candidate_pairs == serialization.load_candidate_pairs(f)
+
+    @pytest.mark.parametrize('sim_size', FLOAT_SIZES)
+    @pytest.mark.parametrize('dset_i_size', UINT_SIZES)
+    @pytest.mark.parametrize('rec_i_size', UINT_SIZES)
+    @pytest.mark.parametrize('length', (0, 5))
+    @pytest.mark.parametrize('version', (0, 2, 172))
+    def test_incorrect_version(
+            self,
+            new_file_function,
+            sim_size, dset_i_size, rec_i_size, length,
+            version):
+        pairs_list = random_pairs_list(dset_i_size, rec_i_size, length)
+        bytes_ = pairs_list_to_bytes(pairs_list, sim_size, dset_i_size, rec_i_size)
+        bytes_[0] = version
+        with new_file_function() as f:
+            f.write(bytes_)
+            f.seek(0)
+            with pytest.raises(ValueError):
+                serialization.load_candidate_pairs(f)
+
+    @pytest.mark.parametrize('sim_size', FLOAT_SIZES)
+    @pytest.mark.parametrize('dset_i_size', UINT_SIZES)
+    @pytest.mark.parametrize('rec_i_size', UINT_SIZES)
+    @pytest.mark.parametrize('length', (0, 5))
+    def test_unsupported_sizes(
+            self,
+            new_file_function,
+            sim_size, dset_i_size, rec_i_size, length):
+        pairs_list = random_pairs_list(dset_i_size, rec_i_size, length)
+        
+        bytes_ = pairs_list_to_bytes(pairs_list, sim_size, dset_i_size, rec_i_size)
+        bytes_[1] = 3
+        with new_file_function() as f:
+            f.write(bytes_)
+            f.seek(0)
+            with pytest.raises(ValueError):
+                serialization.load_candidate_pairs(f)
+        
+        bytes_ = pairs_list_to_bytes(pairs_list, sim_size, dset_i_size, rec_i_size)
+        bytes_[2] = 3
+        with new_file_function() as f:
+            f.write(bytes_)
+            f.seek(0)
+            with pytest.raises(ValueError):
+                serialization.load_candidate_pairs(f)
+        
+        bytes_ = pairs_list_to_bytes(pairs_list, sim_size, dset_i_size, rec_i_size)
+        bytes_[3] = 3
+        with new_file_function() as f:
+            f.write(bytes_)
+            f.seek(0)
+            with pytest.raises(ValueError):
+                serialization.load_candidate_pairs(f)
+
+    def test_empty_file(self, new_file_function):
+        with new_file_function() as f:
+            with pytest.raises(ValueError):
+                serialization.load_candidate_pairs(f)
+
+    def test_incomplete_header(self, new_file_function):
+        with new_file_function() as f:
+            f.write(FORMAT_VERSION.to_bytes(1, 'little'))
+            f.seek(0)
+            with pytest.raises(ValueError):
+                serialization.load_candidate_pairs(f)
+
+            f.seek(0, 2)
+            f.write(DEFAULT_SIZE.to_bytes(1, 'little'))
+            f.seek(0)
+            with pytest.raises(ValueError):
+                serialization.load_candidate_pairs(f)
+
+            f.seek(0, 2)
+            f.write(DEFAULT_SIZE.to_bytes(1, 'little'))
+            f.seek(0)
+            with pytest.raises(ValueError):
+                serialization.load_candidate_pairs(f)
+
+    @pytest.mark.parametrize('sim_size', FLOAT_SIZES)
+    @pytest.mark.parametrize('dset_i_size', UINT_SIZES)
+    @pytest.mark.parametrize('rec_i_size', UINT_SIZES)
+    @pytest.mark.parametrize('preceeding', (0, 5))
+    def test_incomplete_entry(
+            self,
+            new_file_function,
+            sim_size, dset_i_size, rec_i_size,
+            preceeding):
+        pairs_list = random_pairs_list(dset_i_size, rec_i_size, preceeding + 1)
+        bytes_ = pairs_list_to_bytes(pairs_list, sim_size, dset_i_size, rec_i_size)
+        with new_file_function() as f:
+            f.write(bytes_)
+            for _ in range(1, sim_size + 2 * dset_i_size + 2 * rec_i_size):
+                f.seek(-1, 2)
+                f.truncate()
+                f.seek(0)
+                with pytest.raises(ValueError):
+                    serialization.load_candidate_pairs(f)
+
+
+class TestMergeStreams:
+    @pytest.mark.parametrize('split', (1, 2, 5))
+    def test_general(self,
+                     cands_bytes_pair, new_file_function,
+                     split):
+        (_, _, all_pairs_list,
+         (sim_size, dset_i_size, rec_i_size, _)) = cands_bytes_pair
+        pairs_lists = tuple([] for _ in range(split))
+
+        rng = random.Random(RANDOM_SEED)
+        for pair in all_pairs_list:
+            rng.choice(pairs_lists).append(pair)
+
+        with contextlib.ExitStack() as stack:
+            files = tuple(stack.enter_context(new_file_function())
+                          for _ in pairs_lists)
+
+            for f, pairs_list in zip(files, pairs_lists):
+                f.write(pairs_list_to_bytes(pairs_list,
+                                            sim_size, dset_i_size, rec_i_size))
+                f.seek(0)
+
+            f_out = stack.enter_context(new_file_function())
+            serialization.merge_streams(f_out, files)
+            f_out.seek(0)
+            assert f_out.read() == pairs_list_to_bytes(
+                all_pairs_list, sim_size, dset_i_size, rec_i_size)
+
+    def test_no_files(self, new_file_function):
+        with new_file_function() as f:
+            with pytest.raises(ValueError):
+                serialization.merge_streams(f, [])
+
+    @pytest.mark.parametrize('length', (0, 5))
+    @pytest.mark.parametrize('split', (1, 2, 5))
+    def test_sizes(self, new_file_function, length, split):
+        rng = random.Random(RANDOM_SEED)
+        sim_sizes = tuple(rng.choice(FLOAT_SIZES) for _ in range(split))
+        dset_i_sizes = tuple(rng.choice(UINT_SIZES) for _ in range(split))
+        rec_i_sizes = tuple(rng.choice(UINT_SIZES) for _ in range(split))
+
+        with contextlib.ExitStack() as stack:
+            files = tuple(stack.enter_context(new_file_function())
+                          for _ in range(split))
+
+            for i, f, sim_size, dset_i_size, rec_i_size in zip(
+                    itertools.count(),
+                    files,
+                    sim_sizes, dset_i_sizes, rec_i_sizes):
+                pairs_list = random_pairs_list(dset_i_size, rec_i_size, length,
+                                               seed=RANDOM_SEED + i)
+                f.write(pairs_list_to_bytes(pairs_list,
+                                            sim_size, dset_i_size, rec_i_size))
+                f.seek(0)
+
+            f_out = stack.enter_context(new_file_function())
+            serialization.merge_streams(f_out, files)
+            f_out.seek(1)
+            assert int.from_bytes(f_out.read(1), 'little') == max(sim_sizes)
+            assert int.from_bytes(f_out.read(1), 'little') == max(dset_i_sizes)
+            assert int.from_bytes(f_out.read(1), 'little') == max(rec_i_sizes)
+
+    @pytest.mark.parametrize('sim_size', FLOAT_SIZES)
+    @pytest.mark.parametrize('dset_i_size', UINT_SIZES)
+    @pytest.mark.parametrize('rec_i_size', UINT_SIZES)
+    def test_tiebreaking(self,
+                         new_file_function,
+                         sim_size, dset_i_size, rec_i_size):
+        # This order is relied on in the test. Make sure that after
+        # flattening these are still sorted.
+        pairs_zip = (((0.91, 0, 2, 6, 2),
+                      (0.9, 0, 2, 6, 2)),
+                     ((0.8, 1, 4, 2, 8),
+                      (0.8, 2, 4, 2, 8)),
+                     ((0.7, 3, 4, 1, 7),
+                      (0.7, 3, 6, 1, 7)),
+                     ((0.6, 6, 2, 6, 109),
+                      (0.6, 6, 2, 32, 109)),
+                     ((0.5, 43, 45, 13, 62),
+                      (0.5, 43, 45, 13, 232)))
+        for swap in itertools.product((False, True), repeat=len(pairs_zip)):
+            swapped_pair_zip = tuple(
+                pair[::-1] if swap_pair else pair
+                for swap_pair, pair in zip(swap, pairs_zip))
+            swapped_pair0, swapped_pair1 = zip(*swapped_pair_zip)
+            with new_file_function() as f0, new_file_function() as f1:
+                f0.write(pairs_list_to_bytes(
+                    swapped_pair0,
+                    sim_size, dset_i_size, rec_i_size))
+                f0.seek(0)
+                f1.write(pairs_list_to_bytes(
+                    swapped_pair1,
+                    sim_size, dset_i_size, rec_i_size))
+                f1.seek(0)
+
+                with new_file_function() as f_out:
+                    serialization.merge_streams(f_out, [f0, f1])
+                    f_out.seek(0)
+                    bytes_out = f_out.read()
+
+            bytes_sorted = pairs_list_to_bytes(
+                    itertools.chain.from_iterable(pairs_zip),
+                    sim_size, dset_i_size, rec_i_size)
+
+            assert bytes_out == bytes_sorted
+
+    @pytest.mark.parametrize('length', (0, 5))
+    @pytest.mark.parametrize('version', (0, 2, 172))
+    def test_incorrect_version(
+            self,
+            new_file_function,
+            length, version):
+        for invalid_file_i in range(DEFAULT_FILES_NUM):
+            with contextlib.ExitStack() as stack:
+                files = tuple(stack.enter_context(new_file_function())
+                              for _ in range(DEFAULT_FILES_NUM))
+                for i, f in enumerate(files):
+                    pairs_list = random_pairs_list(
+                        DEFAULT_SIZE, DEFAULT_SIZE, length)
+                    bytes_ = pairs_list_to_bytes(
+                        pairs_list, DEFAULT_SIZE, DEFAULT_SIZE, DEFAULT_SIZE)        
+                    bytes_[0] = version if i == invalid_file_i else bytes_[0]
+                    f.write(bytes_)
+                    f.seek(0)
+                with new_file_function() as f_out:
+                    with pytest.raises(ValueError):
+                        serialization.merge_streams(f_out, files)
+
+    @pytest.mark.parametrize('length', (0, 5))
+    def test_unsupported_sizes(
+            self,
+            new_file_function,
+            length):
+        for invalid_file_i, size_pos in itertools.product(
+                range(DEFAULT_FILES_NUM), range(1, 4)):
+            with contextlib.ExitStack() as stack:
+                files = tuple(stack.enter_context(new_file_function())
+                              for _ in range(DEFAULT_FILES_NUM))
+                for i, f in enumerate(files):
+                    pairs_list = random_pairs_list(
+                        DEFAULT_SIZE, DEFAULT_SIZE, length)
+                    bytes_ = pairs_list_to_bytes(
+                        pairs_list, DEFAULT_SIZE, DEFAULT_SIZE, DEFAULT_SIZE)
+                    f.write(bytes_)
+                    if i == invalid_file_i:
+                        f.seek(size_pos)
+                        f.write(UNSUPPORTED_SIZE.to_bytes(1, 'little'))
+                    f.seek(0)
+                with new_file_function() as f_out:
+                    with pytest.raises(ValueError):
+                        serialization.merge_streams(f_out, files)
+
+    def test_empty_file(self, new_file_function):
+        for invalid_file_i in range(DEFAULT_FILES_NUM):
+            with contextlib.ExitStack() as stack:
+                files = tuple(stack.enter_context(new_file_function())
+                              for _ in range(DEFAULT_FILES_NUM))
+                for i, f in enumerate(files):
+                    if i != invalid_file_i:
+                        pairs_list = random_pairs_list(
+                            DEFAULT_SIZE, DEFAULT_SIZE, DEFAULT_LENGTH)
+                        bytes_ = pairs_list_to_bytes(
+                            pairs_list,
+                            DEFAULT_SIZE, DEFAULT_SIZE, DEFAULT_SIZE)
+                        f.write(bytes_)
+                        f.seek(0)
+                with new_file_function() as f_out:
+                    with pytest.raises(ValueError):
+                        serialization.merge_streams(f_out, files)
+
+    def test_incomplete_header(self, new_file_function):
+        for invalid_file_i, header_len in itertools.product(
+                range(DEFAULT_FILES_NUM), range(1, 4)):
+            with contextlib.ExitStack() as stack:
+                files = tuple(stack.enter_context(new_file_function())
+                              for _ in range(DEFAULT_FILES_NUM))
+                for i, f in enumerate(files):
+                    pairs_list = random_pairs_list(
+                        DEFAULT_SIZE, DEFAULT_SIZE, DEFAULT_LENGTH)
+                    bytes_ = pairs_list_to_bytes(
+                        pairs_list, DEFAULT_SIZE, DEFAULT_SIZE, DEFAULT_SIZE)
+                    f.write(bytes_)
+                    if i == invalid_file_i:
+                        f.seek(header_len)
+                        f.truncate()
+                    f.seek(0)
+                with new_file_function() as f_out:
+                    with pytest.raises(ValueError):
+                        serialization.merge_streams(f_out, files)
+
+    @pytest.mark.parametrize('length', (0, 5))
+    def test_pairs_incomplete_entry(self, new_file_function, length):
+        for invalid_file_i in range(DEFAULT_FILES_NUM):
+            with contextlib.ExitStack() as stack:
+                files = tuple(stack.enter_context(new_file_function())
+                              for _ in range(DEFAULT_FILES_NUM))
+                f_out = stack.enter_context(new_file_function())
+                for i, f in enumerate(files):
+                    pairs_list = random_pairs_list(
+                        DEFAULT_SIZE, DEFAULT_SIZE, length + 1)
+                    bytes_ = pairs_list_to_bytes(
+                        pairs_list,
+                        DEFAULT_SIZE, DEFAULT_SIZE, DEFAULT_SIZE)
+                    f.write(bytes_)
+                    f.seek(0)
+
+                for _ in range(1, 5 * DEFAULT_SIZE):
+                    files[invalid_file_i].seek(-1, 2)
+                    files[invalid_file_i].truncate()
+                    files[invalid_file_i].seek(0)
+                    with pytest.raises(ValueError):
+                        serialization.merge_streams(f_out, files)
+
+
+class TestIntegration:
+    def test_dump_load(self, cands_bytes_pair, new_file_function):
+        candidate_pairs, *_ = cands_bytes_pair
+        with new_file_function() as f:
+            serialization.dump_candidate_pairs(f, candidate_pairs)
+            f.seek(0)
+            assert serialization.load_candidate_pairs(f) == candidate_pairs
+
+    @pytest.mark.parametrize('split', (1, 2, 5))
+    def test_merge(self, cands_bytes_pair, new_file_function, split):
+        (sorted_pairs_list, _, all_pairs_list,
+         (sim_size, dset_i_size, rec_i_size, _)) = cands_bytes_pair
+        pairs_lists = tuple([] for _ in range(split))
+
+        rng = random.Random(RANDOM_SEED)
+        for pair in all_pairs_list:
+            rng.choice(pairs_lists).append(pair)
+
+        with contextlib.ExitStack() as stack:
+            files = tuple(stack.enter_context(new_file_function())
+                          for _ in pairs_lists)
+            for f, pairs_list in zip(files, pairs_lists):
+                candidate_pairs = pairs_list_to_candidate_pairs(
+                        pairs_list, sim_size, dset_i_size, rec_i_size)
+                serialization.dump_candidate_pairs(f, candidate_pairs)
+                f.seek(0)
+            with new_file_function() as f_out:
+                serialization.merge_streams(f_out, files)
+                f_out.seek(0)
+                assert (sorted_pairs_list
+                        == serialization.load_candidate_pairs(f_out))

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -45,7 +45,7 @@ def random_pairs_list(sim_size, dset_i_size, rec_i_size,
     rng = random.Random(seed)
     random_pairs = []
     for _ in range(length):
-        # Force single precision
+        # Coerce precision
         float_array[0] = rng.uniform(0, 1)
         sim = float_array[0]
 


### PR DESCRIPTION
Serialise candidate pairs into binary format. This will help us get this code out of the Entity Service.

I realise this is a big pull request, but 70% of the code is testing. This code has a lot of unpleasant edge cases.

@hardbyte is probably in the best position to review this, but since this is a big PR, it would be great if @unzvfu could have a look also.