### PR TITLE
Fix tiebreaking. Fixes #102. I think.

### DIFF
--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -262,7 +262,7 @@ public:
 
 struct score_cmp {
     bool operator()(const Node& a, const Node& b) const {
-        return a.score >= b.score;
+        return a.score > b.score || (a.score == b.score && a.index < b.index);
     }
 };
 

--- a/anonlink/entitymatch.py
+++ b/anonlink/entitymatch.py
@@ -29,7 +29,7 @@ def python_filter_similarity(filters1, filters2, k, threshold):
 
         coeffs = filter(lambda c: c[1] >= threshold,
                         enumerate(map(dicecoeff, filters2)))
-        top_k = sorted(coeffs, key=itemgetter(1), reverse=True)[:k]
+        top_k = sorted(coeffs, key=lambda x: -x[1])[:k]
         result.extend([(i, coeff, j) for j, coeff in top_k])
     return result
 


### PR DESCRIPTION
Python code fixes tiebreaking to prefer records with lower indices. (Previous preferred higher indices.)

I don’t know what the previous C++ code did, but this will consistently prefer records with lower indices.