### PR TITLE
Fix inconsistency when threshold is 0 and one of the popcounts is zero

### DIFF
--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -262,7 +262,7 @@ public:
 
 struct score_cmp {
     bool operator()(const Node& a, const Node& b) const {
-        return a.score >= b.score;
+        return a.score > b.score || (a.score == b.score && a.index < b.index);
     }
 };
 

--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -465,8 +465,18 @@ extern "C"
         node_queue top_k_scores(score_cmp(), std::move(vec));
 
         uint32_t count_one = _popcount_array(comp1, keywords);
-        if (count_one == 0)
-            return 0;
+        if (count_one == 0) {
+            if (threshold > 0) {
+                return 0;
+            }
+
+            for (uint32_t j = 0; j < k; ++j) {
+                scores[j] = 0.0;
+            }
+            for (uint32_t j = 0; j < k; ++j) {
+                indices[j] = j;
+            }
+        }
 
         uint32_t max_popcnt_delta = keybytes * CHAR_BIT; // = bits per key
         if(threshold > 0) {

--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -476,6 +476,8 @@ extern "C"
             for (uint32_t j = 0; j < k; ++j) {
                 indices[j] = j;
             }
+
+            return static_cast<int>(k);
         }
 
         uint32_t max_popcnt_delta = keybytes * CHAR_BIT; // = bits per key

--- a/anonlink/entitymatch.py
+++ b/anonlink/entitymatch.py
@@ -29,7 +29,7 @@ def python_filter_similarity(filters1, filters2, k, threshold):
 
         coeffs = filter(lambda c: c[1] >= threshold,
                         enumerate(map(dicecoeff, filters2)))
-        top_k = sorted(coeffs, key=itemgetter(1), reverse=True)[:k]
+        top_k = sorted(coeffs, key=lambda x: -x[1])[:k]
         result.extend([(i, coeff, j) for j, coeff in top_k])
     return result
 


### PR DESCRIPTION
Fix issue in C++ code when the popcount of `one` is zero and the threshold is 0.

Currently, we output nothing.

But since the threshold is 0, we should be accepting everything, which in this case means outputting the first `k` things. (The scores are provably all zero.)

The test for this exists in #127.