### PR TITLE
Fix greedy solver

### DIFF
--- a/anonlink/solving.py
+++ b/anonlink/solving.py
@@ -13,7 +13,9 @@ import anonlink.typechecking as _typechecking
 
 
 def greedy_solve(
-    candidates: _typechecking.CandidatePairs
+    candidates: _typechecking.CandidatePairs,
+    *,
+    agreement_threshold=.5
 ) -> _typing.Sequence[_typing.Sequence[_typing.Tuple[int, int]]]:
     """ Select matches from candidate pairs using the greedy algorithm.
 
@@ -74,6 +76,10 @@ def greedy_solve(
             i0_mid = id(i0_matches)
             i1_mid = id(i1_matches)
 
+            if i0_mid == i1_mid:
+                # Already matched.
+                continue
+
             # Check if mergeable. matchable_pairs[i0_mid][i1_mid] is the
             # number of pairs they have in common not including the
             # current pair--we add one to include it. The total number
@@ -81,7 +87,7 @@ def greedy_solve(
             # is the number of matchable pairs, then every pair is
             # matchable.
             if (matchable_pairs[i0_mid][i1_mid] + 1
-                == len(i0_matches) * len(i1_matches)):
+                >= len(i0_matches) * len(i1_matches) * agreement_threshold):
                 # Optimise by always extending the bigger group.
                 if len(i0_matches) < len(i1_matches):
                     i0, i1 = i1, i0

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -99,6 +99,15 @@ def test_greedy_fourparty():
     result = greedy_solve(_zip_candidates(candidates))
     _compare_matching(result, [{(0,0), (1,0), (2,0), (3,0)}])
 
+    candidates = [(.9, (0, 0), (1, 0)),
+                  (.8, (1, 0), (3, 0)),
+                  (.7, (2, 0), (3, 0)),
+                  (.6, (0, 0), (2, 0)),
+                  (.5, (0, 0), (3, 0)),
+                  (.4, (0, 0), (1, 1))]
+    result = greedy_solve(_zip_candidates(candidates))
+    _compare_matching(result, [{(0,0), (1,0), (2,0), (3,0)}])
+
 
 def test_inconsistent_dataset_number():
     candidates = (


### PR DESCRIPTION
Fixes greedy solver by letting two groups merge if a specified proportion of their pairs match.

For example, setting this proportion to be .75, we would let A-B and C-D merge if A-C, A-D, and B-C are candidate pairs.

The previous behaviour was to only let two groups merge if all of their pairs are permitted to match. This led to problems where a pair that is not a candidate pair could 'veto' the merger of two large groups. The old behaviour can be reproduced by setting `agreement_threshold=1`.

Added also is a test of the above example. That test fails with the old solver.