### PR TITLE
Dice coefficient: sort pairs by similarity

### DIFF
--- a/anonlink/similarities/_dice_python.py
+++ b/anonlink/similarities/_dice_python.py
@@ -22,6 +22,11 @@ def dice_coefficient_python(
     architecture-specific instructions. It may be slower than an
     accelerated version.
 
+    The returned pairs are sorted in decreasing order of similarity,
+    then in increasing order of the record index in the first dataset,
+    and then in increasing oreder of the record index in the second
+    dataset.
+
     :param datasets: A length 2 sequence of datasets. A dataset is a
         sequence of bitarrays.
     :param threshold: Pairs whose similarity is above this value may be

--- a/anonlink/similarities/_dice_python.py
+++ b/anonlink/similarities/_dice_python.py
@@ -3,10 +3,10 @@ from itertools import repeat
 from numbers import Real
 from typing import Optional, Sequence, Tuple
 
-import numpy as np
 from bitarray import bitarray
 
 from anonlink.typechecking import FloatArrayType, IntArrayType
+from anonlink.similarities._utils import sort_similarities_inplace
 
 __all__ = ['dice_coefficient_python']
 
@@ -66,20 +66,6 @@ def dice_coefficient_python(
         result_indices0.extend(repeat(i, len(top_k)))
         result_indices1.extend(j for j, _ in top_k)
 
-    np_sims = np.frombuffer(result_sims, dtype=result_sims.typecode)
-    np_indices0 = np.frombuffer(result_indices0,
-                                dtype=result_indices0.typecode)
-    np_indices1 = np.frombuffer(result_indices1,
-                                dtype=result_indices1.typecode)
-    
-    np.negative(np_sims, out=np_sims)  # Sort in reverse.
-    # Mergesort is stable. We need that for correct tiebreaking.
-    order = np.argsort(np_sims, kind='mergesort')
-    np.negative(np_sims, out=np_sims)
-
-    # This modifies the original arrays since they share a buffer.
-    np_sims[:] = np_sims[order]
-    np_indices0[:] = np_indices0[order]
-    np_indices1[:] = np_indices1[order]
+    sort_similarities_inplace(result_sims, result_indices0, result_indices1)
     
     return result_sims, (result_indices0, result_indices1)

--- a/anonlink/similarities/_dice_python.py
+++ b/anonlink/similarities/_dice_python.py
@@ -5,8 +5,8 @@ from typing import Optional, Sequence, Tuple
 
 from bitarray import bitarray
 
-from anonlink.typechecking import FloatArrayType, IntArrayType
 from anonlink.similarities._utils import sort_similarities_inplace
+from anonlink.typechecking import FloatArrayType, IntArrayType
 
 __all__ = ['dice_coefficient_python']
 

--- a/anonlink/similarities/_dice_python.py
+++ b/anonlink/similarities/_dice_python.py
@@ -10,9 +10,6 @@ from anonlink.typechecking import FloatArrayType, IntArrayType
 
 __all__ = ['dice_coefficient_python']
 
-_SIM_ARRAY_TYPE = 'd'
-_INDEX_ARRAY_TYPE = 'I'
-
 
 def dice_coefficient_python(
     datasets: Sequence[Sequence[bitarray]],
@@ -44,9 +41,9 @@ def dice_coefficient_python(
             f'too many datasets (expected 2, got {n_datasets})')
     filters0, filters1 = datasets
 
-    result_sims: FloatArrayType = array(_SIM_ARRAY_TYPE)
-    result_indices0: IntArrayType = array(_INDEX_ARRAY_TYPE)
-    result_indices1: IntArrayType = array(_INDEX_ARRAY_TYPE)
+    result_sims: FloatArrayType = array('d')
+    result_indices0: IntArrayType = array('I')
+    result_indices1: IntArrayType = array('I')
 
     if not filters0 or not filters1:
         # Empty result of the correct type.
@@ -69,9 +66,11 @@ def dice_coefficient_python(
         result_indices0.extend(repeat(i, len(top_k)))
         result_indices1.extend(j for j, _ in top_k)
 
-    np_sims = np.frombuffer(result_sims, dtype=_SIM_ARRAY_TYPE)
-    np_indices0 = np.frombuffer(result_indices0, dtype=_INDEX_ARRAY_TYPE)
-    np_indices1 = np.frombuffer(result_indices1, dtype=_INDEX_ARRAY_TYPE)
+    np_sims = np.frombuffer(result_sims, dtype=result_sims.typecode)
+    np_indices0 = np.frombuffer(result_indices0,
+                                dtype=result_indices0.typecode)
+    np_indices1 = np.frombuffer(result_indices1,
+                                dtype=result_indices1.typecode)
     
     np.negative(np_sims, out=np_sims)  # Sort in reverse.
     # Mergesort is stable. We need that for correct tiebreaking.

--- a/anonlink/similarities/_dice_python.py
+++ b/anonlink/similarities/_dice_python.py
@@ -24,7 +24,7 @@ def dice_coefficient_python(
 
     The returned pairs are sorted in decreasing order of similarity,
     then in increasing order of the record index in the first dataset,
-    and then in increasing oreder of the record index in the second
+    and then in increasing order of the record index in the second
     dataset.
 
     :param datasets: A length 2 sequence of datasets. A dataset is a

--- a/anonlink/similarities/_dice_x86.py
+++ b/anonlink/similarities/_dice_x86.py
@@ -33,7 +33,7 @@ def dice_coefficient_accelerated(
 
     The returned pairs are sorted in decreasing order of similarity,
     then in increasing order of the record index in the first dataset,
-    and then in increasing oreder of the record index in the second
+    and then in increasing order of the record index in the second
     dataset.
 
     :param datasets: A length 2 sequence of datasets. A dataset is a

--- a/anonlink/similarities/_dice_x86.py
+++ b/anonlink/similarities/_dice_x86.py
@@ -3,10 +3,10 @@ from itertools import chain, groupby, repeat
 from numbers import Real
 from typing import Optional, Sequence, Tuple
 
-import numpy as np
 from bitarray import bitarray
 
 from anonlink._entitymatcher import ffi, lib
+from anonlink.similarities._utils import sort_similarities_inplace
 from anonlink.typechecking import FloatArrayType, IntArrayType
 
 __all__ = ['dice_coefficient_accelerated']
@@ -30,6 +30,11 @@ def dice_coefficient_accelerated(
 
     We assume all filters are the same length and that this length is a
     multiple of 64 bits.
+
+    The returned pairs are sorted in decreasing order of similarity,
+    then in increasing order of the record index in the first dataset,
+    and then in increasing oreder of the record index in the second
+    dataset.
 
     :param datasets: A length 2 sequence of datasets. A dataset is a
         sequence of bitarrays.
@@ -112,20 +117,6 @@ def dice_coefficient_accelerated(
         result_indices0.extend(repeat(i, matches))
         result_indices1.extend(c_indices[0:matches])
 
-    np_sims = np.frombuffer(result_sims, dtype=result_sims.typecode)
-    np_indices0 = np.frombuffer(result_indices0,
-                                dtype=result_indices0.typecode)
-    np_indices1 = np.frombuffer(result_indices1,
-                                dtype=result_indices1.typecode)
-    
-    np.negative(np_sims, out=np_sims)  # Sort in reverse.
-    # Mergesort is stable. We need that for correct tiebreaking.
-    order = np.argsort(np_sims, kind='mergesort')
-    np.negative(np_sims, out=np_sims)
-
-    # This modifies the original arrays since they share a buffer.
-    np_sims[:] = np_sims[order]
-    np_indices0[:] = np_indices0[order]
-    np_indices1[:] = np_indices1[order]
+    sort_similarities_inplace(result_sims, result_indices0, result_indices1)
 
     return result_sims, (result_indices0, result_indices1)

--- a/anonlink/similarities/_dice_x86.py
+++ b/anonlink/similarities/_dice_x86.py
@@ -11,10 +11,6 @@ from anonlink.typechecking import FloatArrayType, IntArrayType
 
 __all__ = ['dice_coefficient_accelerated']
 
-# These must match the C++ code
-_SIM_ARRAY_TYPE = 'd'
-_INDEX_ARRAY_TYPE = 'I'
-
 
 def _all_equal(iterable):
     # https://docs.python.org/3/library/itertools.html#itertools-recipes
@@ -55,9 +51,9 @@ def dice_coefficient_accelerated(
             f'too many datasets (expected 2, got {n_datasets})')
     filters0, filters1 = datasets
 
-    result_sims: FloatArrayType = array(_SIM_ARRAY_TYPE)
-    result_indices0: IntArrayType = array(_INDEX_ARRAY_TYPE)
-    result_indices1: IntArrayType = array(_INDEX_ARRAY_TYPE)
+    result_sims: FloatArrayType = array('d')
+    result_indices0: IntArrayType = array('I')
+    result_indices1: IntArrayType = array('I')
 
     if not filters0 or not filters1:
         # Empty result of the correct type.
@@ -116,9 +112,11 @@ def dice_coefficient_accelerated(
         result_indices0.extend(repeat(i, matches))
         result_indices1.extend(c_indices[0:matches])
 
-    np_sims = np.frombuffer(result_sims, dtype=_SIM_ARRAY_TYPE)
-    np_indices0 = np.frombuffer(result_indices0, dtype=_INDEX_ARRAY_TYPE)
-    np_indices1 = np.frombuffer(result_indices1, dtype=_INDEX_ARRAY_TYPE)
+    np_sims = np.frombuffer(result_sims, dtype=result_sims.typecode)
+    np_indices0 = np.frombuffer(result_indices0,
+                                dtype=result_indices0.typecode)
+    np_indices1 = np.frombuffer(result_indices1,
+                                dtype=result_indices1.typecode)
     
     np.negative(np_sims, out=np_sims)  # Sort in reverse.
     # Mergesort is stable. We need that for correct tiebreaking.

--- a/anonlink/similarities/_utils.py
+++ b/anonlink/similarities/_utils.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from anonlink.typechecking import FloatArrayType, IntArrayType
+
+
+def sort_similarities_inplace(
+    sims: FloatArrayType,
+    rec_is0: IntArrayType,
+    rec_is1: IntArrayType
+) -> None:
+    np_sims = np.frombuffer(sims, dtype=sims.typecode)
+    np_indices0 = np.frombuffer(rec_is0, dtype=rec_is0.typecode)
+    np_indices1 = np.frombuffer(rec_is1, dtype=rec_is1.typecode)
+    
+    np.negative(np_sims, out=np_sims)  # Sort in reverse.
+    # Mergesort is stable. We need that for correct tiebreaking.
+    order = np.argsort(np_sims, kind='mergesort')
+    np.negative(np_sims, out=np_sims)
+
+    # This modifies the original arrays since they share a buffer.
+    np_sims[:] = np_sims[order]
+    np_indices0[:] = np_indices0[order]
+    np_indices1[:] = np_indices1[order]

--- a/tests/test_similarity_dice.py
+++ b/tests/test_similarity_dice.py
@@ -251,3 +251,28 @@ class TestBloomFilterComparison:
         assert sims.typecode in FLOAT_ARRAY_TYPES
         assert (rec_is0.typecode in UINT_ARRAY_TYPES
                 and rec_is1.typecode in UINT_ARRAY_TYPES)
+
+    @pytest.mark.parametrize('sim_fun', SIM_FUNS)
+    def test_order(self, sim_fun):
+        similarity = sim_fun(
+            self.filters, self.default_threshold, self.default_k)
+        sims, (rec_is0, rec_is1) = similarity
+        for i in range(len(sims) - 1):
+            sim_a, rec_i0_a, rec_i1_a = sims[i], rec_is0[i], rec_is1[i]
+            sim_b, rec_i0_b, rec_i1_b = sims[i+1], rec_is0[i+1], rec_is1[i+1]
+            if sim_a > sim_b:
+                pass  # Correctly ordered!
+            elif sim_a == sim_b:
+                if rec_i0_a < rec_i0_b:
+                    pass  # Correctly ordered!
+                elif rec_i0_a == rec_i0_b:
+                    if rec_i1_a < rec_i1_b:
+                        pass  # Correctly ordered!
+                    elif rec_i1_a == rec_i1_b:
+                        assert False, 'duplicate entry'
+                    else:
+                        assert False, 'incorrect tiebreaking on second index'
+                else:
+                    assert False, 'incorrect tiebreaking on first index'
+            else:
+                assert False, 'incorrect similarity sorting'


### PR DESCRIPTION
Naive solution to Dice coefficient code not sorting candidate pairs, as described in #135. This PR improves accuracy but decreases speed—both these effects are significant in some cases but negligible in others.

~~Please do not merge this PR as the issue is still under discussion.~~

Edit: consensus is to make this change. The changes made in this PR can be optimised later if need be.