### PR TITLE
Improve chunking output

### DIFF
--- a/anonlink/concurrency.py
+++ b/anonlink/concurrency.py
@@ -47,13 +47,14 @@ def split_to_chunks(
 ) -> _typing.Iterable[ChunkInfo]:
     """Split datasets into chunks for parallel processing.
 
-    Resulting chunks are dictionaries with two keys: "datasetIndices"
-    and "ranges". The value for "datasetIndices" is a length 2 list of
-    the two datasets that we are comparing in this chunk. The value for
-    "ranges" is a length 2 list of ranges within those datasets. A range
-    is a length 2 list [a, b] representing range(a, b).
+    Resulting chunks are length 2 list of dictionaries. Each dictionary
+    represents one data source for the chunk: it has a 'datasetIndex'
+    key which maps to the index of the dataset as an integer, and it has
+    a 'range' key mapping to the range of records within this dataset. A
+    range is a length 2 list [a, b] representing range(a, b).
 
-    Example: {"datasetIndices": [2, 4], "ranges": [[3, 21], [18, 20]]}
+    Example: [{"datasetIndex": 2, "range": [3, 21]},
+              {"datasetIndex": 4, "range": [18, 20]}]
     means that this chunk compares (0-indexed) datasets 2 and 4. We are
     looking at elements 3-20 (inclusive) of dataset 2 and elements 18
     and 19 of dataset 4.
@@ -83,4 +84,5 @@ def split_to_chunks(
         chunks1 = round(size1 * chunk_size0 / chunk_size_aim_float) or 1
         for c0, c1 in _itertools.product(
                 _chunks_1d(size0, chunks0), _chunks_1d(size1, chunks1)):
-            yield {'datasetIndices': [i0, i1], 'ranges': [c0, c1]}
+            yield [{'datasetIndex': i0, 'range': c0},
+                   {'datasetIndex': i1, 'range': c1}]

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -21,10 +21,12 @@ def test_chunk_size(datasets, chunk_size_aim):
                                          dataset_sizes=datasets)
     for chunk in chunks:
         size = 1
-        i0, i1 = chunk['datasetIndices']
-        for a, b in chunk['ranges']:
+        for source in chunk:
+            a, b = source['range']
             assert a <= b
             size *= b - a
+        i0 = chunk[0]['datasetIndex']
+        i1 = chunk[1]['datasetIndex']
         assert (chunk_size_aim / 4 < size
                 or 4 * chunk_size_aim > datasets[i0] * datasets[i1])
         assert size < chunk_size_aim * 4
@@ -41,8 +43,10 @@ def test_comparison_coverage(datasets, chunk_size_aim):
     chunks = concurrency.split_to_chunks(chunk_size_aim,
                                          dataset_sizes=datasets)
     for chunk in chunks:
-        i0, i1 = chunk['datasetIndices']
-        r0, r1 = chunk['ranges']
+        i0 = chunk[0]['datasetIndex']
+        i1 = chunk[1]['datasetIndex']
+        r0 = chunk[0]['range']
+        r1 = chunk[1]['range']
         for j0, j1 in itertools.product(range(*r0), range(*r1)):
             # This will raise KeyError if we have duplicates
             all_comparisons.remove((i0, i1, j0, j1))


### PR DESCRIPTION
Previously `concurrency.split_to_chunks` output, for each chunk, a dictionary where each value was a 2-list for the two source datasets. An output format that’s easier to process is a 2-list of dictionaries.