### PR TITLE
Concurrency: process chunk

### DIFF
--- a/anonlink/concurrency.py
+++ b/anonlink/concurrency.py
@@ -149,6 +149,13 @@ def process_chunk(
         raise ValueError(
             f'number of datasets does not match chunk (expected {len(chunk)}, '
             f'got {len(datasets)})')
+    for i, dataset_chunk in enumerate(chunk):
+        if 'datasetIndex' not in dataset_chunk:
+            raise ValueError(f"invalid chunk: expected value for "
+                             f"'datasetIndex' at index {i}")
+        if 'range' not in dataset_chunk:
+            raise ValueError(f"invalid chunk: expected value for "
+                             f"'range' at index {i}")
     for i, dataset_chunk, dataset_records in zip(
                 _itertools.count(), chunk, datasets):
         a, b = dataset_chunk['range']
@@ -156,6 +163,11 @@ def process_chunk(
             raise ValueError(
                 f'size of dataset at index {i} does not match chunk (expected '
                 f'{b - a}, got {len(dataset_records)})')
+    if len(chunk) != 2:
+        raise NotImplementedError(
+            f'only binary matching is currently supported '
+            f'(chunk has {len(chunk)} datasets)')
+
 
     sims, (rec_is0, rec_is1) = similarity_f(datasets, threshold, k=k)
     assert len(sims) == len(rec_is0) == len(rec_is1)

--- a/anonlink/concurrency.py
+++ b/anonlink/concurrency.py
@@ -93,12 +93,18 @@ def split_to_chunks(
                    {'datasetIndex': i1, 'range': c1}]
 
 
-def _get_dataset_indices(dataset_chunk, size):
+def _get_dataset_indices(
+    dataset_chunk: DatasetChunkInfo,
+    size: int
+) -> _typechecking.IntArrayType:
     index = dataset_chunk['datasetIndex']
     return _array.array('I', (index,)) * size
 
 
-def _offset_record_indices_inplace(dataset_chunk, rec_is):
+def _offset_record_indices_inplace(
+    dataset_chunk: DatasetChunkInfo,
+    rec_is: _typechecking.IntArrayType
+) -> None:
     a, _ = dataset_chunk['range']
     np_rec_is = _np.frombuffer(rec_is, dtype=rec_is.typecode)
     np_rec_is += a

--- a/anonlink/concurrency.py
+++ b/anonlink/concurrency.py
@@ -111,6 +111,40 @@ def process_chunk(
     threshold: _numbers.Real,
     k: _typing.Optional[_numbers.Integral] = None
 ) -> _typechecking.CandidatePairs:
+    """Find candidate pairs for the chunk.
+
+    Calls the similarity function, offsets record indices by the
+    required amount, and adds dataset index information.
+
+    :param chunk: Chunk to process, as returned by `split_to_chunks`.
+    :param datasets: A sequence of two datasets. Each dataset should
+        contain as many records as required by `chunk`. It is up to you
+        to extract the correct range from the larger dataset.
+    :param similarity_f: A function that computes a similarity matrix
+        between two sequences of hashes and finds candidates above the
+        threshold.
+    :param threshold: The similarity threshold. We accept pairs that
+        have similarity of at least this value.
+    :param k: Only permit this many candidate pairs per dataset pair per
+        record. Set to `None` to permit all pairs above with similarity
+        at least `threshold`.
+
+    :return: A 3-tuple `(similarity, dataset_i, record_i)`. `dataset_i`
+        and `record_i` are sequences of sequences. Every sequence in
+        `dataset_i` has the same length as `similarity`; also, every
+        sequence in `record_i` has the same length as `similarity`.
+        Currently `dataset_i` and `record_i` have length 2, but this may
+        be changed in the future.
+            Every valid index `i` corresponds to one candidate match.
+        `dataset[0][i]` is the index of the dataset of the first record
+        in the pair; `record[0][i]` is this record's index in its
+        dataset. `dataset_[1][i]` is the index of the dataset of the
+        second record in the pair; `record_[1][i]` is this record's
+        index in its dataset. `similarity[i]` is the pair's similarity;
+        this value will be greater than `threshold`.
+    """
+
+
     if len(chunk) != len(datasets):
         raise ValueError(
             f'number of datasets does not match chunk (expected {len(chunk)}, '

--- a/anonlink/concurrency.py
+++ b/anonlink/concurrency.py
@@ -98,7 +98,7 @@ def _get_dataset_indices(dataset_chunk, size):
     return _array.array('I', (index,)) * size
 
 
-def _offset_record_indices(dataset_chunk, rec_is):
+def _offset_record_indices_inplace(dataset_chunk, rec_is):
     a, _ = dataset_chunk['range']
     np_rec_is = _np.frombuffer(rec_is, dtype=rec_is.typecode)
     np_rec_is += a
@@ -161,9 +161,9 @@ def process_chunk(
     assert len(sims) == len(rec_is0) == len(rec_is1)
 
     dset_is0 = _get_dataset_indices(chunk[0], len(sims))
-    _offset_record_indices(chunk[0], rec_is0)
+    _offset_record_indices_inplace(chunk[0], rec_is0)
     
     dset_is1 = _get_dataset_indices(chunk[1], len(sims))
-    _offset_record_indices(chunk[1], rec_is1)
+    _offset_record_indices_inplace(chunk[1], rec_is1)
 
     return sims, (dset_is0, dset_is1), (rec_is0, rec_is1)

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,4 +1,6 @@
+import array
 import itertools
+import random
 
 import pytest
 
@@ -9,7 +11,7 @@ DATASET_NUMS = (0, 1, 2, 3)
 DATASETS = tuple(itertools.chain.from_iterable(
     itertools.product(DATASET_SIZES, repeat=n) for n in DATASET_NUMS))
 CHUNK_SIZE_AIMS = (1, 10, 100)
-
+SEED = 52
 
 
 @pytest.mark.parametrize('datasets', DATASETS)
@@ -32,7 +34,6 @@ def test_chunk_size(datasets, chunk_size_aim):
         assert size < chunk_size_aim * 4
                 
 
-
 @pytest.mark.parametrize('datasets', DATASETS)
 @pytest.mark.parametrize('chunk_size_aim', CHUNK_SIZE_AIMS)
 def test_comparison_coverage(datasets, chunk_size_aim):
@@ -52,3 +53,63 @@ def test_comparison_coverage(datasets, chunk_size_aim):
             all_comparisons.remove((i0, i1, j0, j1))
     # Make sure we've touched everything (so our set is empty)
     assert not all_comparisons
+
+
+@pytest.mark.parametrize('dataset_size0', (1, 100))
+@pytest.mark.parametrize('dataset_size1', (1, 100))
+@pytest.mark.parametrize('k_', (None, 5))
+@pytest.mark.parametrize('threshold_', (0.5, 0.9))
+def test_process_chunk(dataset_size0, dataset_size1, k_, threshold_):
+    rng = random.Random(51)
+    offset0 = rng.randrange(1000)
+    offset1 = rng.randrange(1000)
+
+    results_num = dataset_size0 * dataset_size1 // 10
+
+    dset_i0 = 5
+    dset_i1 = 9
+
+    chunk = [{'datasetIndex': dset_i0,
+              'range': [offset0, offset0 + dataset_size0]},
+             {'datasetIndex': dset_i1,
+              'range': [offset1, offset1 + dataset_size1]}]
+
+    dataset0 = [rng.randrange(100) for _ in range(dataset_size0)]
+    dataset1 = [rng.randrange(100) for _ in range(dataset_size1)]
+    datasets_ = [dataset0, dataset1]
+
+    sims = array.array('d', (rng.uniform(threshold_, 1)
+                                 for _ in range(results_num)))
+    rec_is0 = array.array('I')
+    rec_is1 = array.array('I')
+    for i0, i1 in rng.choices(list(itertools.product(range(dataset_size0),
+                                                     range(dataset_size1))),
+                              k=results_num):
+        rec_is0.append(i0)
+        rec_is1.append(i1)
+
+    def similarity_f(datasets, threshold, k):
+        assert datasets == datasets_
+        assert k == k_
+        assert threshold == threshold_
+        
+        # Copy so we can modify in-place and compare
+        return sims, (array.array('I', rec_is0), array.array('I', rec_is1))
+
+    sims_, (dset_is0_, dset_is1_), (rec_is0_, rec_is1_) \
+        = concurrency.process_chunk(
+            chunk,
+            datasets_,
+            similarity_f,
+            threshold_,
+            k=k_)
+
+    assert sims == sims_
+    assert len(rec_is0) == len(rec_is0_)
+    assert all(rec_i0 + offset0 == rec_i0_
+               for rec_i0, rec_i0_ in zip(rec_is0, rec_is0_))
+    assert len(rec_is1) == len(rec_is1_)
+    assert all(rec_i1 + offset1 == rec_i1_
+               for rec_i1, rec_i1_ in zip(rec_is1, rec_is1_))
+    assert list(dset_is0_) == [dset_i0] * results_num
+    assert list(dset_is1_) == [dset_i1] * results_num

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -11,7 +11,7 @@ DATASET_NUMS = (0, 1, 2, 3)
 DATASETS = tuple(itertools.chain.from_iterable(
     itertools.product(DATASET_SIZES, repeat=n) for n in DATASET_NUMS))
 CHUNK_SIZE_AIMS = (1, 10, 100)
-SEED = 52
+SEED = 51
 
 
 @pytest.mark.parametrize('datasets', DATASETS)
@@ -60,7 +60,7 @@ def test_comparison_coverage(datasets, chunk_size_aim):
 @pytest.mark.parametrize('k_', (None, 5))
 @pytest.mark.parametrize('threshold_', (0.5, 0.9))
 def test_process_chunk(dataset_size0, dataset_size1, k_, threshold_):
-    rng = random.Random(51)
+    rng = random.Random(SEED)
     offset0 = rng.randrange(1000)
     offset1 = rng.randrange(1000)
 


### PR DESCRIPTION
Make `concurrency.process_chunk` function. It's a wrapper around a similarity function that does two things:
1. Adds the appropriate offsets to the record indices (the offset is determined by the way we chunk)
2. Turns the result of the similarity function into valid `CandidatePairs` by adding dataset index information.

Minor additional change: Fix Mypy typing following #139.