### PR TITLE
Fix bug where solver returns duplicate groups

### DIFF
--- a/anonlink/solving.py
+++ b/anonlink/solving.py
@@ -137,5 +137,8 @@ def greedy_solve(
 
         raise RuntimeError('non-exhaustive cases')
                 
-    # Return all nontrivial groups
-    return tuple(group for group in matches.values() if len(group) > 1)
+    # Return all nontrivial groups without duplication
+    deduplicated_groups = {id(group): group
+                           for group in matches.values()
+                           if len(group) > 1}
+    return tuple(deduplicated_groups.values())

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -21,9 +21,11 @@ def _zip_candidates(candidates):
 
 
 def _compare_matching(result, truth):
-    result = set(map(frozenset, result))
-    truth = set(map(frozenset, truth))
-    assert result == truth
+    result_set = set(map(frozenset, result))
+    assert len(result) == len(result_set)
+    truth_set = set(map(frozenset, truth))
+    assert len(truth) == len(truth_set)
+    assert result_set == truth_set
 
 
 def test_greedy_twoparty():


### PR DESCRIPTION
- Fix bug where the tuple of groups returned by the greedy solver contained duplicate groups.
- Change tests to fail if greedy solver returns duplicates.