### PR TITLE
Feature dump to iter

### DIFF
--- a/anonlink/serialization.py
+++ b/anonlink/serialization.py
@@ -88,10 +88,9 @@ def _bytes_iter_from_iterable(
     rec_i_t_size: int,
     iterable: _CandidatePairIter
 ) -> _typing.Iterable[bytes]:
-    # Fail without writing if the parameters are incorrect.
+    # Fail without yielding if the parameters are incorrect.
     entry_struct = _entry_struct(sim_t_size, dset_i_t_size, rec_i_t_size)
     
-    # Write header.
     yield _HEADER_STRUCT.pack(1, sim_t_size, dset_i_t_size, rec_i_t_size)
     yield from _itertools.starmap(entry_struct.pack, iterable)
 

--- a/anonlink/serialization.py
+++ b/anonlink/serialization.py
@@ -7,6 +7,7 @@ compatibility will be attempted, but not guaranteed.
 import array as _array
 import heapq as _heapq
 import io as _io
+import itertools as _itertools
 import struct as _struct
 import typing as _typing
 
@@ -81,21 +82,28 @@ def _entry_struct(
     return _struct.Struct(f"<{sim_t}2{dset_i_t}2{rec_i_t}")
     
 
-def _dump_from_iterable(
-    f: _typing.BinaryIO,
+def _bytes_iter_from_iterable(
     sim_t_size: int,
     dset_i_t_size: int,
     rec_i_t_size: int,
     iterable: _CandidatePairIter
-) -> None:
+) -> _typing.Iterable[bytes]:
     # Fail without writing if the parameters are incorrect.
     entry_struct = _entry_struct(sim_t_size, dset_i_t_size, rec_i_t_size)
     
     # Write header.
-    f.write(_HEADER_STRUCT.pack(1, sim_t_size, dset_i_t_size, rec_i_t_size))
-    
-    for entry in iterable:
-        f.write(entry_struct.pack(*entry))
+    yield _HEADER_STRUCT.pack(1, sim_t_size, dset_i_t_size, rec_i_t_size)
+    yield from _itertools.starmap(entry_struct.pack, iterable)
+
+
+def _write_bytes_iter(
+    f: _typing.BinaryIO,
+    bytes_iter: _typing.Iterable[bytes]
+) -> None:
+    # Caution! Assumes that all bytes in bytes_iter are nonempty!
+    # Consume iterable at C speed. `f.write` returns >0 if we are
+    # writing >0 bytes. Hence, `all` exhausts the iterator.
+    all(map(f.write, bytes_iter))
 
 
 def _entries_iterable(
@@ -135,13 +143,13 @@ def _load_to_iterable(
             sim_t_size, dset_i_t_size, rec_i_t_size)
 
 
-def dump_candidate_pairs(
-    candidate_pairs: _typechecking.CandidatePairs,
-    f: _typing.BinaryIO
-) -> None:
-    """Dump candidate pairs to file.
+def dump_candidate_pairs_iter(
+    candidate_pairs: _typechecking.CandidatePairs
+) -> _typing.Iterable[bytes]:
+    """Dump candidate pairs as an iterable of bytes objects.
 
-    :param f: Binary buffer to write to.
+    No guarantees are made about the size of those bytes objects.
+
     :param candidate_pairs: Candidate pairs, as returned by a similarity
         function or `load_candidate_pairs`.
     """
@@ -158,8 +166,22 @@ def dump_candidate_pairs(
     dset_i_t_size = max(dset_is0.itemsize, dset_is1.itemsize)
     rec_i_t_size = max(rec_is0.itemsize, rec_is1.itemsize)
 
-    _dump_from_iterable(
-        f, sim_t_size, dset_i_t_size, rec_i_t_size, iterable)
+    return _bytes_iter_from_iterable(
+        sim_t_size, dset_i_t_size, rec_i_t_size, iterable)
+
+
+def dump_candidate_pairs(
+    candidate_pairs: _typechecking.CandidatePairs,
+    f: _typing.BinaryIO
+) -> None:
+    """Dump candidate pairs to file.
+
+    :param f: Binary buffer to write to.
+    :param candidate_pairs: Candidate pairs, as returned by a similarity
+        function or `load_candidate_pairs`.
+    """
+    bytes_iter = dump_candidate_pairs_iter(candidate_pairs)
+    _write_bytes_iter(f, bytes_iter)
 
 
 def load_candidate_pairs(f: _typing.BinaryIO) -> _typechecking.CandidatePairs:
@@ -203,11 +225,10 @@ def load_candidate_pairs(f: _typing.BinaryIO) -> _typechecking.CandidatePairs:
     return sims, (dset_is0, dset_is1), (rec_is0, rec_is1)
 
 
-def merge_streams(
-    files_in: _typing.Iterable[_typing.BinaryIO],
-    f_out: _typing.BinaryIO
-) -> None:
-    """Merge multiple files with serialised candidate pairs.
+def merge_streams_iter(
+    files_in: _typing.Iterable[_typing.BinaryIO]
+) -> _typing.Iterable[bytes]:
+    """Merge multiple files with candidate pairs to iterable of bytes.
 
     This function preserves the candidate pairs' sorted order. It avoids
     loading everything into memory.
@@ -218,7 +239,6 @@ def merge_streams(
     Note that you cannot simply concatenate two files to obtain a valid
     candidate pairs dump.
 
-    :param f_out: Binary buffer write the merged candidate pairs to.
     :param files_in: Sequence of files to read from.
     """
     if not files_in:
@@ -235,6 +255,28 @@ def merge_streams(
     # indices and then with record indices, in increasing order.
     sorted_iterable = _heapq.merge(*file_iterables,
                                    key=lambda x: (-x[0],) + x[1:])
-    _dump_from_iterable(f_out,
-                        sim_t_size, dset_i_t_size, rec_i_t_size,
-                        sorted_iterable)
+    return _bytes_iter_from_iterable(
+        sim_t_size, dset_i_t_size, rec_i_t_size,
+        sorted_iterable)
+
+
+def merge_streams(
+    files_in: _typing.Iterable[_typing.BinaryIO],
+    f_out: _typing.BinaryIO
+) -> None:
+    """Merge multiple files with serialised candidate pairs.
+
+    This function preserves the candidate pairs' sorted order. It avoids
+    loading everything into memory.
+
+    The field sizes in the resulting file will be chosen so no
+    information is lost.
+     
+    Note that you cannot simply concatenate two files to obtain a valid
+    candidate pairs dump.
+
+    :param files_in: Sequence of files to read from.
+    :param f_out: Binary buffer write the merged candidate pairs to.
+    """
+    bytes_iter = merge_streams_iter(files_in)
+    _write_bytes_iter(f_out, bytes_iter)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -115,6 +115,7 @@ def new_file_function(request, tmpdir_path):
 
 
 def consume(iterator):
+    # https://docs.python.org/3/library/itertools.html#itertools-recipes
     "Consume iterator entirely."
     # Use functions that consume iterators at C speed.
     # Feed the entire iterator into a zero-length deque.

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,4 +1,5 @@
 import array
+import collections
 import contextlib
 import io
 import itertools
@@ -113,11 +114,30 @@ def new_file_function(request, tmpdir_path):
     raise ValueError('invalid param')
 
 
+def consume(iterator):
+    "Consume iterator entirely."
+    # Use functions that consume iterators at C speed.
+    # Feed the entire iterator into a zero-length deque.
+    collections.deque(iterator, maxlen=0)
+
+
+# Hack so we can test the functions returning an iterable of bytes
+# without redoing all the tests... First write to file, then simply test
+# like the functions that dump straight to files.
+def dump_iter_to_file(candidate_pairs, f):
+    consume(map(f.write,
+                serialization.dump_candidate_pairs_iter(candidate_pairs)))
+def merge_iter_to_file(files_in, f_out):
+    consume(map(f_out.write, serialization.merge_streams_iter(files_in)))
+
+
+@pytest.mark.parametrize('dump_function', [serialization.dump_candidate_pairs,
+                                           dump_iter_to_file])
 class TestDumpCandidatePairs:
-    def test_general(self, cands_bytes_pair, new_file_function):
+    def test_general(self, cands_bytes_pair, new_file_function, dump_function):
         candidate_pairs, bytes_, *_ = cands_bytes_pair
         with new_file_function() as f:
-            serialization.dump_candidate_pairs(candidate_pairs, f)
+            dump_function(candidate_pairs, f)
             f.seek(0)
             assert f.read() == bytes_
 
@@ -235,12 +255,14 @@ class TestLoadCandidatePairs:
                 with pytest.raises(ValueError):
                     serialization.load_candidate_pairs(f)
 
-
+@pytest.mark.parametrize('merge_function', [serialization.merge_streams,
+                                            merge_iter_to_file])
 class TestMergeStreams:
     @pytest.mark.parametrize('split', (1, 2, 5))
     def test_general(self,
                      cands_bytes_pair, new_file_function,
-                     split):
+                     split,
+                     merge_function):
         (_, _, all_pairs_list,
          (sim_size, dset_i_size, rec_i_size, _)) = cands_bytes_pair
         pairs_lists = tuple([] for _ in range(split))
@@ -259,19 +281,19 @@ class TestMergeStreams:
                 f.seek(0)
 
             f_out = stack.enter_context(new_file_function())
-            serialization.merge_streams(files, f_out)
+            merge_function(files, f_out)
             f_out.seek(0)
             assert f_out.read() == pairs_list_to_bytes(
                 all_pairs_list, sim_size, dset_i_size, rec_i_size)
 
-    def test_no_files(self, new_file_function):
+    def test_no_files(self, new_file_function, merge_function):
         with new_file_function() as f:
             with pytest.raises(ValueError):
-                serialization.merge_streams([], f)
+                merge_function([], f)
 
     @pytest.mark.parametrize('length', (0, 5))
     @pytest.mark.parametrize('split', (1, 2, 5))
-    def test_sizes(self, new_file_function, length, split):
+    def test_sizes(self, new_file_function, length, split, merge_function):
         rng = random.Random(RANDOM_SEED)
         sim_sizes = tuple(rng.choice(FLOAT_SIZES) for _ in range(split))
         dset_i_sizes = tuple(rng.choice(UINT_SIZES) for _ in range(split))
@@ -293,7 +315,7 @@ class TestMergeStreams:
                 f.seek(0)
 
             f_out = stack.enter_context(new_file_function())
-            serialization.merge_streams(files, f_out)
+            merge_function(files, f_out)
             f_out.seek(1)
             assert int.from_bytes(f_out.read(1), 'little') == max(sim_sizes)
             assert int.from_bytes(f_out.read(1), 'little') == max(dset_i_sizes)
@@ -304,7 +326,8 @@ class TestMergeStreams:
     @pytest.mark.parametrize('rec_i_size', UINT_SIZES)
     def test_tiebreaking(self,
                          new_file_function,
-                         sim_size, dset_i_size, rec_i_size):
+                         sim_size, dset_i_size, rec_i_size,
+                         merge_function):
         # This order is relied on in the test. Make sure that after
         # flattening these are still sorted.
         pairs_zip = (((0.91, 0, 2, 6, 2),
@@ -333,7 +356,7 @@ class TestMergeStreams:
                 f1.seek(0)
 
                 with new_file_function() as f_out:
-                    serialization.merge_streams([f0, f1], f_out)
+                    merge_function([f0, f1], f_out)
                     f_out.seek(0)
                     bytes_out = f_out.read()
 
@@ -348,7 +371,8 @@ class TestMergeStreams:
     def test_incorrect_version(
             self,
             new_file_function,
-            length, version):
+            length, version,
+            merge_function):
         for invalid_file_i in range(DEFAULT_FILES_NUM):
             with contextlib.ExitStack() as stack:
                 files = tuple(stack.enter_context(new_file_function())
@@ -363,13 +387,14 @@ class TestMergeStreams:
                     f.seek(0)
                 with new_file_function() as f_out:
                     with pytest.raises(ValueError):
-                        serialization.merge_streams(files, f_out)
+                        merge_function(files, f_out)
 
     @pytest.mark.parametrize('length', (0, 5))
     def test_unsupported_sizes(
             self,
             new_file_function,
-            length):
+            length,
+            merge_function):
         for invalid_file_i, size_pos in itertools.product(
                 range(DEFAULT_FILES_NUM), range(1, 4)):
             with contextlib.ExitStack() as stack:
@@ -387,9 +412,9 @@ class TestMergeStreams:
                     f.seek(0)
                 with new_file_function() as f_out:
                     with pytest.raises(ValueError):
-                        serialization.merge_streams(files, f_out)
+                        merge_function(files, f_out)
 
-    def test_empty_file(self, new_file_function):
+    def test_empty_file(self, new_file_function, merge_function):
         for invalid_file_i in range(DEFAULT_FILES_NUM):
             with contextlib.ExitStack() as stack:
                 files = tuple(stack.enter_context(new_file_function())
@@ -406,9 +431,9 @@ class TestMergeStreams:
                         f.seek(0)
                 with new_file_function() as f_out:
                     with pytest.raises(ValueError):
-                        serialization.merge_streams(files, f_out)
+                        merge_function(files, f_out)
 
-    def test_incomplete_header(self, new_file_function):
+    def test_incomplete_header(self, new_file_function, merge_function):
         for invalid_file_i, header_len in itertools.product(
                 range(DEFAULT_FILES_NUM), range(1, 4)):
             with contextlib.ExitStack() as stack:
@@ -427,10 +452,14 @@ class TestMergeStreams:
                     f.seek(0)
                 with new_file_function() as f_out:
                     with pytest.raises(ValueError):
-                        serialization.merge_streams(files, f_out)
+                        merge_function(files, f_out)
 
     @pytest.mark.parametrize('length', (0, 5))
-    def test_pairs_incomplete_entry(self, new_file_function, length):
+    def test_pairs_incomplete_entry(
+            self,
+            new_file_function,
+            length,
+            merge_function):
         for invalid_file_i in range(DEFAULT_FILES_NUM):
             with contextlib.ExitStack() as stack:
                 files = tuple(stack.enter_context(new_file_function())
@@ -450,19 +479,33 @@ class TestMergeStreams:
                     files[invalid_file_i].truncate()
                     files[invalid_file_i].seek(0)
                     with pytest.raises(ValueError):
-                        serialization.merge_streams(files, f_out)
+                        merge_function(files, f_out)
 
 
+@pytest.mark.parametrize('dump_function', [serialization.dump_candidate_pairs,
+                                           dump_iter_to_file])
 class TestIntegration:
-    def test_dump_load(self, cands_bytes_pair, new_file_function):
+    def test_dump_load(
+            self,
+            cands_bytes_pair,
+            new_file_function,
+            dump_function):
         candidate_pairs, *_ = cands_bytes_pair
         with new_file_function() as f:
-            serialization.dump_candidate_pairs(candidate_pairs, f)
+            dump_function(candidate_pairs, f)
             f.seek(0)
             assert serialization.load_candidate_pairs(f) == candidate_pairs
 
     @pytest.mark.parametrize('split', (1, 2, 5))
-    def test_merge(self, cands_bytes_pair, new_file_function, split):
+    @pytest.mark.parametrize('merge_function', [serialization.merge_streams,
+                                                merge_iter_to_file])
+    def test_merge(
+            self,
+            cands_bytes_pair,
+            new_file_function,
+            split,
+            dump_function,
+            merge_function):
         (sorted_pairs_list, _, all_pairs_list,
          (sim_size, dset_i_size, rec_i_size, _)) = cands_bytes_pair
         pairs_lists = tuple([] for _ in range(split))
@@ -477,10 +520,10 @@ class TestIntegration:
             for f, pairs_list in zip(files, pairs_lists):
                 candidate_pairs = pairs_list_to_candidate_pairs(
                         pairs_list, sim_size, dset_i_size, rec_i_size)
-                serialization.dump_candidate_pairs(candidate_pairs, f)
+                dump_function(candidate_pairs, f)
                 f.seek(0)
             with new_file_function() as f_out:
-                serialization.merge_streams(files, f_out)
+                merge_function(files, f_out)
                 f_out.seek(0)
                 assert (sorted_pairs_list
                         == serialization.load_candidate_pairs(f_out))


### PR DESCRIPTION
Ability to dump to an iterable of `bytes` instead of straight to file.

This lets us put an `io.RawIOBase` wrapper around the serialised stream.