### PR TITLE
Add deprecation warnings to old API

### DIFF
--- a/anonlink/_deprecation.py
+++ b/anonlink/_deprecation.py
@@ -1,0 +1,35 @@
+import functools as _functools
+import typing as _typing
+import warnings as _warnings
+
+
+def _warn_deprecated(
+    module_name: str,
+    f_name: str,
+    replacement: _typing.Optional[str]
+) -> None:
+    msg = f'anonlink.{module_name}.{f_name} has been deprecated '
+    if replacement is not None:
+        msg += f'(use anonlink.{replacement} instead)'
+    else:
+        msg += 'without replacement'
+    _warnings.warn(msg, DeprecationWarning, stacklevel=3)
+
+
+# Mypy typing this is too hard. ¯\_(ツ)_/¯
+def make_decorator(module_name):
+    def deprecate_decorator(f=None, *, replacement=None):
+        def deprecate_decorator_inner(f):
+            @_functools.wraps(f)
+            def f_inner(*args, **kwargs):
+                _warn_deprecated(module_name, f.__name__, replacement)
+                return f(*args, **kwargs)
+            return f_inner
+        # Use decorator with or without arguments.
+        if f is None:
+            return deprecate_decorator_inner
+        else:
+            return deprecate_decorator_inner(f)
+    return deprecate_decorator
+
+

--- a/anonlink/bloommatcher.py
+++ b/anonlink/bloommatcher.py
@@ -1,6 +1,3 @@
-import inspect
-import warnings
-
 import anonlink._deprecation
 from anonlink._entitymatcher import ffi, lib
 

--- a/anonlink/bloommatcher.py
+++ b/anonlink/bloommatcher.py
@@ -1,6 +1,20 @@
+import inspect
+import warnings
+
 from anonlink._entitymatcher import ffi, lib
 
 __author__ = 'Stephen Hardy, Brian Thorne'
+
+
+def _fname():
+    return inspect.currentframe().f_back.f_back.f_code.co_name
+def _deprecation(use_instead=None):
+    msg = (f'anonlink.bloommatcher.{_fname()} has been deprecated ')
+    if use_instead is not None:
+        msg += f'(use anonlink.{use_instead} instead)'
+    else:
+        msg += 'without replacement'
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
 
 def dicecoeff_pure_python(e1, e2):
@@ -13,6 +27,7 @@ def dicecoeff_pure_python(e1, e2):
     :param e2: bitarray of same length as e1
     :return: real 0-1 similarity measure
     """
+    _deprecation('similarities.dice_coefficient_python')
     count1 = e1.count()
     count2 = e2.count()
     combined_count = count1 + count2
@@ -33,6 +48,7 @@ def dicecoeff_native(e1, e2):
     :param e2: bitarray of same length as e1
     :return: real 0-1 similarity measure
     """
+    _deprecation('similarities.dice_coefficient_accelerated')
     e1array = ffi.new("char[]", e1.tobytes())
     e2array = ffi.new("char[]", e2.tobytes())
     return lib.dice_coeff(e1array, e2array, len(e1array))
@@ -44,6 +60,7 @@ def dicecoeff(e1, e2):
 
     :return: real 0-1 similarity measure
     """
+    _deprecation('similarities.dice_coefficient')
     if e1.length() == e2.length() and (e1.length()/8) % 8 == 0:
         return dicecoeff_native(e1, e2)
     else:
@@ -59,6 +76,7 @@ def dicecoeff_precount(e1, e2, count):
     :param count: float bitcount1 + bitcount2
     :return: real 0-1 similarity measure
     """
+    _deprecation()
     if count == 0:
         return 0
     return 2*(e1 & e2).count()/count
@@ -72,6 +90,7 @@ def tanimoto(e1, e2):
 
     :return: real 0-1 similarity measure
     """
+    _deprecation()
     return (e1 & e2).count() / float((e1 | e2).count())
 
 
@@ -84,5 +103,6 @@ def tanimoto_precount(e1, e2, count):
     :param count: float bitcount1 + bitcount2
     :return: real 0-1 similarity measure
     """
+    _deprecation()
     a = (e1 & e2).count()
     return a / float(count - a)

--- a/anonlink/bloommatcher.py
+++ b/anonlink/bloommatcher.py
@@ -1,22 +1,15 @@
 import inspect
 import warnings
 
+import anonlink._deprecation
 from anonlink._entitymatcher import ffi, lib
 
 __author__ = 'Stephen Hardy, Brian Thorne'
 
-
-def _fname():
-    return inspect.currentframe().f_back.f_back.f_code.co_name
-def _deprecation(use_instead=None):
-    msg = (f'anonlink.bloommatcher.{_fname()} has been deprecated ')
-    if use_instead is not None:
-        msg += f'(use anonlink.{use_instead} instead)'
-    else:
-        msg += 'without replacement'
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+deprecated = anonlink._deprecation.make_decorator(__name__)
 
 
+@deprecated(replacement='similarities.dice_coefficient_python')
 def dicecoeff_pure_python(e1, e2):
     """
     Dice coefficient measures the similarity of two bit patterns.
@@ -27,7 +20,6 @@ def dicecoeff_pure_python(e1, e2):
     :param e2: bitarray of same length as e1
     :return: real 0-1 similarity measure
     """
-    _deprecation('similarities.dice_coefficient_python')
     count1 = e1.count()
     count2 = e2.count()
     combined_count = count1 + count2
@@ -38,6 +30,7 @@ def dicecoeff_pure_python(e1, e2):
         return 2.0 * overlap_count / combined_count
 
 
+@deprecated(replacement='similarities.dice_coefficient_accelerated')
 def dicecoeff_native(e1, e2):
     """
     Dice coefficient measures the similarity of two bit patterns.
@@ -48,25 +41,25 @@ def dicecoeff_native(e1, e2):
     :param e2: bitarray of same length as e1
     :return: real 0-1 similarity measure
     """
-    _deprecation('similarities.dice_coefficient_accelerated')
     e1array = ffi.new("char[]", e1.tobytes())
     e2array = ffi.new("char[]", e2.tobytes())
     return lib.dice_coeff(e1array, e2array, len(e1array))
 
 
+@deprecated(replacement='similarities.dice_coefficient')
 def dicecoeff(e1, e2):
     """
     Dice coefficient measures the similarity of two bit patterns
 
     :return: real 0-1 similarity measure
     """
-    _deprecation('similarities.dice_coefficient')
     if e1.length() == e2.length() and (e1.length()/8) % 8 == 0:
         return dicecoeff_native(e1, e2)
     else:
         return dicecoeff_pure_python(e1, e2)
 
 
+@deprecated
 def dicecoeff_precount(e1, e2, count):
     """
     Dice coefficient measures the similarity of two bit patterns
@@ -76,12 +69,12 @@ def dicecoeff_precount(e1, e2, count):
     :param count: float bitcount1 + bitcount2
     :return: real 0-1 similarity measure
     """
-    _deprecation()
     if count == 0:
         return 0
     return 2*(e1 & e2).count()/count
 
 
+@deprecated
 def tanimoto(e1, e2):
     """
     Tanimoto coefficient measures the similarity of two bit patterns.
@@ -90,10 +83,10 @@ def tanimoto(e1, e2):
 
     :return: real 0-1 similarity measure
     """
-    _deprecation()
     return (e1 & e2).count() / float((e1 | e2).count())
 
 
+@deprecated
 def tanimoto_precount(e1, e2, count):
     """
     Tanimoto coefficient measures the similarity of two bit patterns
@@ -103,6 +96,5 @@ def tanimoto_precount(e1, e2, count):
     :param count: float bitcount1 + bitcount2
     :return: real 0-1 similarity measure
     """
-    _deprecation()
     a = (e1 & e2).count()
     return a / float(count - a)

--- a/anonlink/distributed_processing.py
+++ b/anonlink/distributed_processing.py
@@ -5,7 +5,6 @@ Concurrent implementations.
 """
 
 import concurrent.futures
-import warnings
 
 import anonlink._deprecation
 import anonlink.entitymatch

--- a/anonlink/distributed_processing.py
+++ b/anonlink/distributed_processing.py
@@ -39,6 +39,7 @@ def calculate_filter_similarity(filters1, filters2, k, threshold):
     :param threshold:
     :return:
     """
+
     results = []
     chunk_size = int(20000000 / len(filters2))
 

--- a/anonlink/distributed_processing.py
+++ b/anonlink/distributed_processing.py
@@ -7,15 +7,15 @@ Concurrent implementations.
 import concurrent.futures
 import warnings
 
+import anonlink._deprecation
 import anonlink.entitymatch
 from anonlink.util import chunks
 
+deprecated = anonlink._deprecation.make_decorator(__name__)
 
+
+@deprecated(replacement='concurrency.process_chunk')
 def calc_chunk_result(chunk_number, chunk, filters2, k, threshold):
-    warnings.warn(
-        'anonlink.distributed_processing.calc_chunk_result has been '
-        'deprecated (use anonlink.concurrency.process_chunk instead)',
-        DeprecationWarning)
     chunk_results = anonlink.entitymatch.calculate_filter_similarity(chunk, filters2, k, threshold)
 
     partial_sparse_result = []
@@ -28,6 +28,7 @@ def calc_chunk_result(chunk_number, chunk, filters2, k, threshold):
     return partial_sparse_result
 
 
+@deprecated
 def calculate_filter_similarity(filters1, filters2, k, threshold):
     """
     Example way of computing similarity scores in parallel.
@@ -38,10 +39,6 @@ def calculate_filter_similarity(filters1, filters2, k, threshold):
     :param threshold:
     :return:
     """
-    warnings.warn(
-        'anonlink.distributed_processing.calculate_filter_similarity has '
-        'been deprecated without replacement',
-        DeprecationWarning)
     results = []
     chunk_size = int(20000000 / len(filters2))
 

--- a/anonlink/distributed_processing.py
+++ b/anonlink/distributed_processing.py
@@ -5,11 +5,17 @@ Concurrent implementations.
 """
 
 import concurrent.futures
+import warnings
+
 import anonlink.entitymatch
 from anonlink.util import chunks
 
 
 def calc_chunk_result(chunk_number, chunk, filters2, k, threshold):
+    warnings.warn(
+        'anonlink.distributed_processing.calc_chunk_result has been '
+        'deprecated (use anonlink.concurrency.process_chunk instead)',
+        DeprecationWarning)
     chunk_results = anonlink.entitymatch.calculate_filter_similarity(chunk, filters2, k, threshold)
 
     partial_sparse_result = []
@@ -32,7 +38,10 @@ def calculate_filter_similarity(filters1, filters2, k, threshold):
     :param threshold:
     :return:
     """
-
+    warnings.warn(
+        'anonlink.distributed_processing.calculate_filter_similarity has '
+        'been deprecated without replacement',
+        DeprecationWarning)
     results = []
     chunk_size = int(20000000 / len(filters2))
 

--- a/anonlink/entitymatch.py
+++ b/anonlink/entitymatch.py
@@ -1,5 +1,7 @@
+import inspect
 from itertools import repeat
 import logging
+import warnings
 
 from anonlink._entitymatcher import ffi, lib
 
@@ -9,6 +11,17 @@ from operator import itemgetter
 from . import bloommatcher as bm
 
 log = logging.getLogger('anonlink.entitymatch')
+
+
+def _fname():
+    return inspect.currentframe().f_back.f_back.f_code.co_name
+def _deprecation(use_instead=None):
+    msg = (f'anonlink.entitymatch.{_fname()} has been deprecated ')
+    if use_instead is not None:
+        msg += f'(use anonlink.{use_instead} instead)'
+    else:
+        msg += 'without replacement'
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
 
 def python_filter_similarity(filters1, filters2, k, threshold):
@@ -22,6 +35,7 @@ def python_filter_similarity(filters1, filters2, k, threshold):
         - the similarity score between 0 and 1 of the k matches above threshold
         - The index in filters2 of the best match
     """
+    _deprecation('similarities.dice_coefficient_python')
     result = []
     for i, f1 in enumerate(filters1):
         def dicecoeff(x):
@@ -41,6 +55,7 @@ def cffi_filter_similarity_k(filters1, filters2, k, threshold):
     bits.
 
     """
+    _deprecation('similarities.dice_coefficient_accelerated')
     length_f1 = len(filters1)
     length_f2 = len(filters2)
 
@@ -112,6 +127,7 @@ def greedy_solver(sparse_similarity_matrix):
 
     :param sparse_similarity_matrix: Iterable of tuples: (indx_a, similarity_score, indx_b)
     """
+    _deprecation('solving.greedy_solve')
     mapping = {}
 
     # Indices of filters which have been claimed
@@ -136,6 +152,7 @@ def calculate_mapping_greedy(filters1, filters2, k, threshold):
 
     :returns A mapping dictionary of index in filters1 to index in filters2.
     """
+    _deprecation()
 
     log.info('Solving with greedy solver')
 
@@ -169,6 +186,7 @@ def calculate_filter_similarity(filters1, filters2, k, threshold, use_python=Fal
             - the similarity score between 0 and 1 of the best match
             - The index in filters2 of the best match
     """
+    _deprecation('similarities.dice_coefficient')
     if not filters1 or not filters2:
         raise ValueError('empty input')
     # use C++ version by default

--- a/anonlink/entitymatch.py
+++ b/anonlink/entitymatch.py
@@ -8,22 +8,14 @@ from anonlink._entitymatcher import ffi, lib
 import sys
 from operator import itemgetter
 
+import anonlink._deprecation
 from . import bloommatcher as bm
 
+deprecated = anonlink._deprecation.make_decorator(__name__)
 log = logging.getLogger('anonlink.entitymatch')
 
 
-def _fname():
-    return inspect.currentframe().f_back.f_back.f_code.co_name
-def _deprecation(use_instead=None):
-    msg = (f'anonlink.entitymatch.{_fname()} has been deprecated ')
-    if use_instead is not None:
-        msg += f'(use anonlink.{use_instead} instead)'
-    else:
-        msg += 'without replacement'
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
-
-
+@deprecated(replacement='similarities.dice_coefficient_python')
 def python_filter_similarity(filters1, filters2, k, threshold):
     """Pure python method for determining Bloom Filter similarity
 
@@ -35,7 +27,6 @@ def python_filter_similarity(filters1, filters2, k, threshold):
         - the similarity score between 0 and 1 of the k matches above threshold
         - The index in filters2 of the best match
     """
-    _deprecation('similarities.dice_coefficient_python')
     result = []
     for i, f1 in enumerate(filters1):
         def dicecoeff(x):
@@ -48,6 +39,7 @@ def python_filter_similarity(filters1, filters2, k, threshold):
     return result
 
 
+@deprecated(replacement='similarities.dice_coefficient_accelerated')
 def cffi_filter_similarity_k(filters1, filters2, k, threshold):
     """Accelerated method for determining Bloom Filter similarity.
 
@@ -55,7 +47,6 @@ def cffi_filter_similarity_k(filters1, filters2, k, threshold):
     bits.
 
     """
-    _deprecation('similarities.dice_coefficient_accelerated')
     length_f1 = len(filters1)
     length_f2 = len(filters2)
 
@@ -121,13 +112,13 @@ def cffi_filter_similarity_k(filters1, filters2, k, threshold):
     return result
 
 
+@deprecated(replacement='solving.greedy_solve')
 def greedy_solver(sparse_similarity_matrix):
     """
     For optimal results consider sorting input by score for each row.
 
     :param sparse_similarity_matrix: Iterable of tuples: (indx_a, similarity_score, indx_b)
     """
-    _deprecation('solving.greedy_solve')
     mapping = {}
 
     # Indices of filters which have been claimed
@@ -141,6 +132,7 @@ def greedy_solver(sparse_similarity_matrix):
     return mapping
 
 
+@deprecated
 def calculate_mapping_greedy(filters1, filters2, k, threshold):
     """
     Brute-force one-shot solver.
@@ -152,7 +144,6 @@ def calculate_mapping_greedy(filters1, filters2, k, threshold):
 
     :returns A mapping dictionary of index in filters1 to index in filters2.
     """
-    _deprecation()
 
     log.info('Solving with greedy solver')
 
@@ -160,6 +151,7 @@ def calculate_mapping_greedy(filters1, filters2, k, threshold):
     return greedy_solver(sparse_matrix)
 
 
+@deprecated(replacement='similarities.dice_coefficient')
 def calculate_filter_similarity(filters1, filters2, k, threshold, use_python=False):
     """Computes a sparse similarity matrix with:
         - size no larger than k * len(filters1)
@@ -186,7 +178,6 @@ def calculate_filter_similarity(filters1, filters2, k, threshold, use_python=Fal
             - the similarity score between 0 and 1 of the best match
             - The index in filters2 of the best match
     """
-    _deprecation('similarities.dice_coefficient')
     if not filters1 or not filters2:
         raise ValueError('empty input')
     # use C++ version by default

--- a/anonlink/entitymatch.py
+++ b/anonlink/entitymatch.py
@@ -1,7 +1,5 @@
-import inspect
 from itertools import repeat
 import logging
-import warnings
 
 from anonlink._entitymatcher import ffi, lib
 

--- a/anonlink/network_flow.py
+++ b/anonlink/network_flow.py
@@ -4,10 +4,7 @@ Solves pairwise matches for the entire network at once.
 Given a sparse, weighted, bipartite graph determine the matching.
 """
 
-import inspect
 import logging
-import warnings
-
 import networkx as nx
 from networkx.algorithms import bipartite
 

--- a/anonlink/network_flow.py
+++ b/anonlink/network_flow.py
@@ -11,16 +11,13 @@ import warnings
 import networkx as nx
 from networkx.algorithms import bipartite
 
+import anonlink._deprecation
+
+deprecated = anonlink._deprecation.make_decorator(__name__)
 log = logging.getLogger('anonlink.networkflow')
 
-def _fname():
-    return inspect.currentframe().f_back.f_back.f_code.co_name
-def _deprecation():
-    msg = (f'anonlink.network_flow.{_fname()} has been deprecated without '
-           f'replacement')
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
-
+@deprecated
 def calculate_network(similarity, cutoff):
     """Given an adjacency matrix of edge weights, apply a
     threshold to the connections and construct a graph.
@@ -29,7 +26,6 @@ def calculate_network(similarity, cutoff):
     :param cutoff: The threshold for including a connection
     :return: The resulting networkx graph.
     """
-    _deprecation()
     G = nx.DiGraph()
     logging.debug('Applying threshold to network')
     for (idx1, score, idx2) in similarity:
@@ -53,6 +49,7 @@ def _to_int_map(network, find_pair):
     return entityMap
 
 
+@deprecated
 def calculate_entity_mapping(G, method=None):
     """Given the networkx graph, calculate a dictionary mapping
     each row node to the most highly similar column node.
@@ -71,7 +68,6 @@ def calculate_entity_mapping(G, method=None):
     :return: A dictionary mapping of row index to column index. If no mate
     is found, the node isn't included.
     """
-    _deprecation()
 
     if method == 'bipartite':
         log.info('Solving entity matches with bipartite maximum matching solver')
@@ -122,6 +118,7 @@ def calculate_entity_mapping(G, method=None):
     return entity_map
 
 
+@deprecated
 def map_entities(weights, threshold, method=None):
     """Calculate a dictionary mapping using similarity scores.
 
@@ -134,7 +131,6 @@ def map_entities(weights, threshold, method=None):
         - 'weighted' - the `networkx.max_weight_matching` (slowest but most accurate
           with close matches)
     """
-    _deprecation()
 
     network = calculate_network(weights, threshold)
     return calculate_entity_mapping(network, method)

--- a/anonlink/network_flow.py
+++ b/anonlink/network_flow.py
@@ -4,11 +4,21 @@ Solves pairwise matches for the entire network at once.
 Given a sparse, weighted, bipartite graph determine the matching.
 """
 
+import inspect
 import logging
+import warnings
+
 import networkx as nx
 from networkx.algorithms import bipartite
 
 log = logging.getLogger('anonlink.networkflow')
+
+def _fname():
+    return inspect.currentframe().f_back.f_back.f_code.co_name
+def _deprecation():
+    msg = (f'anonlink.network_flow.{_fname()} has been deprecated without '
+           f'replacement')
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
 
 def calculate_network(similarity, cutoff):
@@ -19,6 +29,7 @@ def calculate_network(similarity, cutoff):
     :param cutoff: The threshold for including a connection
     :return: The resulting networkx graph.
     """
+    _deprecation()
     G = nx.DiGraph()
     logging.debug('Applying threshold to network')
     for (idx1, score, idx2) in similarity:
@@ -60,6 +71,7 @@ def calculate_entity_mapping(G, method=None):
     :return: A dictionary mapping of row index to column index. If no mate
     is found, the node isn't included.
     """
+    _deprecation()
 
     if method == 'bipartite':
         log.info('Solving entity matches with bipartite maximum matching solver')
@@ -122,6 +134,7 @@ def map_entities(weights, threshold, method=None):
         - 'weighted' - the `networkx.max_weight_matching` (slowest but most accurate
           with close matches)
     """
+    _deprecation()
 
     network = calculate_network(weights, threshold)
     return calculate_entity_mapping(network, method)

--- a/anonlink/util.py
+++ b/anonlink/util.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3.4
 
-import inspect
 import os
 import random
-import warnings
 from bitarray import bitarray
 from timeit import default_timer as timer
 

--- a/anonlink/util.py
+++ b/anonlink/util.py
@@ -7,29 +7,21 @@ import warnings
 from bitarray import bitarray
 from timeit import default_timer as timer
 
+import anonlink._deprecation
 from anonlink._entitymatcher import ffi, lib
 
-def _fname():
-    return inspect.currentframe().f_back.f_back.f_code.co_name
-def _deprecation(use_instead=None):
-    msg = (f'anonlink.util.{_fname()} has been '
-           f'deprecated ')
-    if use_instead is not None:
-        msg += f'(use anonlink.{use_instead} instead)'
-    else:
-        msg += 'without replacement'
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+deprecated = anonlink._deprecation.make_decorator(__name__)
 
 
+@deprecated
 def generate_bitarray(length):
-    _deprecation()
     a = bitarray(endian=['little', 'big'][random.randint(0, 1)])
     a.frombytes(os.urandom(length//8))
     return a
 
 
+@deprecated
 def generate_clks(n):
-    _deprecation()
     res = []
     for i in range(n):
         ba = generate_bitarray(1024)
@@ -37,6 +29,7 @@ def generate_clks(n):
     return res
 
 
+@deprecated
 def popcount_vector(bitarrays, use_python=True):
     """Return a list containing the popcounts of the elements of
     bitarrays, and the time (in seconds) it took. If use_python is
@@ -48,7 +41,6 @@ def popcount_vector(bitarrays, use_python=True):
     it is currently more expensive to call our C implementation
     than just calling bitarray.count()
     """
-    _deprecation()
     # Use Python
     if use_python:
         start = timer()
@@ -67,8 +59,8 @@ def popcount_vector(bitarrays, use_python=True):
     return [c_popcounts[i] for i in range(n)], ms * 1e-3
 
 
+@deprecated(replacement='concurrency.split_to_chunks')
 def chunks(l, n):
     """Yield successive n-sized chunks from l."""
-    _deprecation('concurrency.split_to_chunks')
     for i in range(0, len(l), n):
         yield l[i:i + n]

--- a/anonlink/util.py
+++ b/anonlink/util.py
@@ -1,20 +1,35 @@
 #!/usr/bin/env python3.4
 
+import inspect
 import os
 import random
+import warnings
 from bitarray import bitarray
 from timeit import default_timer as timer
 
 from anonlink._entitymatcher import ffi, lib
 
+def _fname():
+    return inspect.currentframe().f_back.f_back.f_code.co_name
+def _deprecation(use_instead=None):
+    msg = (f'anonlink.util.{_fname()} has been '
+           f'deprecated ')
+    if use_instead is not None:
+        msg += f'(use anonlink.{use_instead} instead)'
+    else:
+        msg += 'without replacement'
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
 
 def generate_bitarray(length):
+    _deprecation()
     a = bitarray(endian=['little', 'big'][random.randint(0, 1)])
     a.frombytes(os.urandom(length//8))
     return a
 
 
 def generate_clks(n):
+    _deprecation()
     res = []
     for i in range(n):
         ba = generate_bitarray(1024)
@@ -33,6 +48,7 @@ def popcount_vector(bitarrays, use_python=True):
     it is currently more expensive to call our C implementation
     than just calling bitarray.count()
     """
+    _deprecation()
     # Use Python
     if use_python:
         start = timer()
@@ -53,5 +69,6 @@ def popcount_vector(bitarrays, use_python=True):
 
 def chunks(l, n):
     """Yield successive n-sized chunks from l."""
+    _deprecation('concurrency.split_to_chunks')
     for i in range(0, len(l), n):
         yield l[i:i + n]


### PR DESCRIPTION
By our [deprecation timeline](https://github.com/n1analytics/anonlink/releases/tag/v0.9.0), v0.10.0 needs to raise a warning if the old API is used.