### PR TITLE
Fix wheel build

### DIFF
--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -18,4 +18,4 @@ done
 
 # Install packages and test
 "${PYBIN}/pip" install anonlink --no-index -f /io/wheelhouse
-(cd "$HOME"; "${PYBIN}/pytest" /io/tests)
+(cd "$HOME"; "${PYBIN}/pytest" /io/tests -W ignore:DeprecationWarning)


### PR DESCRIPTION
Travis wheel build fails. The tests it runs emit lots of `DeprecationWarning`s. These will now be ignored.