### PR TITLE
Use correct name for SMC

### DIFF
--- a/anonlink/similarities/__init__.py
+++ b/anonlink/similarities/__init__.py
@@ -5,13 +5,14 @@ similarities. A threshold must be passed: only record pairs with
 similarity of at least this threshold are returned. We call these the
 candidate pairs.
 
-Currently, the Dice Coefficient and Hamming Similarity are implemented.
-These work on binary strings. However, other similarity functions are
-possible as well.
+Currently, the Dice Coefficient and the Simple Matching Coefficient are
+implemented. These work on binary strings. However, other similarity
+functions are possible as well.
 """
 
 from anonlink.similarities._dice_python import dice_coefficient_python
-from anonlink.similarities._hamming import hamming_similarity
+from anonlink.similarities._smc import (hamming_similarity,
+                                        simple_matching_coefficient)
 
 try:
     from anonlink.similarities._dice_x86 import dice_coefficient_accelerated

--- a/tests/test_similarity_smc.py
+++ b/tests/test_similarity_smc.py
@@ -4,34 +4,37 @@ import random
 import pytest
 from bitarray import bitarray
 
-from anonlink.similarities._hamming import _hamming_sim
-from anonlink.similarities import hamming_similarity
+from anonlink.similarities._smc import _smc_sim
+from anonlink.similarities import (hamming_similarity,
+                                   simple_matching_coefficient)
+
+SIM_FUNS = [hamming_similarity, simple_matching_coefficient]
 
 
-def test_hamming_sim_k():
+def test_smc_sim_k():
     # This tests an internal function. It may need to change if the
-    # implementation of `hamming_similarity` changes.
-    assert _hamming_sim(bitarray('0'), bitarray('0')) == 1
-    assert _hamming_sim(bitarray('0'), bitarray('1')) == 0
-    assert _hamming_sim(bitarray('1'), bitarray('0')) == 0
-    assert _hamming_sim(bitarray('1'), bitarray('1')) == 1
+    # implementation of `simple_matching_coefficient` changes.
+    assert _smc_sim(bitarray('0'), bitarray('0')) == 1
+    assert _smc_sim(bitarray('0'), bitarray('1')) == 0
+    assert _smc_sim(bitarray('1'), bitarray('0')) == 0
+    assert _smc_sim(bitarray('1'), bitarray('1')) == 1
 
-    assert _hamming_sim(bitarray('00'), bitarray('00')) == 1
-    assert _hamming_sim(bitarray('00'), bitarray('01')) == .5
-    assert _hamming_sim(bitarray('00'), bitarray('10')) == .5
-    assert _hamming_sim(bitarray('00'), bitarray('11')) == 0
-    assert _hamming_sim(bitarray('01'), bitarray('00')) == .5
-    assert _hamming_sim(bitarray('01'), bitarray('01')) == 1
-    assert _hamming_sim(bitarray('01'), bitarray('10')) == 0
-    assert _hamming_sim(bitarray('01'), bitarray('11')) == .5
-    assert _hamming_sim(bitarray('10'), bitarray('00')) == .5
-    assert _hamming_sim(bitarray('10'), bitarray('01')) == 0
-    assert _hamming_sim(bitarray('10'), bitarray('10')) == 1
-    assert _hamming_sim(bitarray('10'), bitarray('11')) == .5
-    assert _hamming_sim(bitarray('11'), bitarray('00')) == 0
-    assert _hamming_sim(bitarray('11'), bitarray('01')) == .5
-    assert _hamming_sim(bitarray('11'), bitarray('10')) == .5
-    assert _hamming_sim(bitarray('11'), bitarray('11')) == 1
+    assert _smc_sim(bitarray('00'), bitarray('00')) == 1
+    assert _smc_sim(bitarray('00'), bitarray('01')) == .5
+    assert _smc_sim(bitarray('00'), bitarray('10')) == .5
+    assert _smc_sim(bitarray('00'), bitarray('11')) == 0
+    assert _smc_sim(bitarray('01'), bitarray('00')) == .5
+    assert _smc_sim(bitarray('01'), bitarray('01')) == 1
+    assert _smc_sim(bitarray('01'), bitarray('10')) == 0
+    assert _smc_sim(bitarray('01'), bitarray('11')) == .5
+    assert _smc_sim(bitarray('10'), bitarray('00')) == .5
+    assert _smc_sim(bitarray('10'), bitarray('01')) == 0
+    assert _smc_sim(bitarray('10'), bitarray('10')) == 1
+    assert _smc_sim(bitarray('10'), bitarray('11')) == .5
+    assert _smc_sim(bitarray('11'), bitarray('00')) == 0
+    assert _smc_sim(bitarray('11'), bitarray('01')) == .5
+    assert _smc_sim(bitarray('11'), bitarray('10')) == .5
+    assert _smc_sim(bitarray('11'), bitarray('11')) == 1
 
 
 def _sanity_check_candidates(sims, indices, candidates):
@@ -57,11 +60,11 @@ def datasets(request):
 
     return result
 
-
 @pytest.mark.parametrize('threshold', [1.0, 0.6, 0.0])
+@pytest.mark.parametrize('f', SIM_FUNS)
 class TestHammingSimilarity:
-    def test_no_k(self, datasets, threshold):
-        sims, indices = hamming_similarity(datasets, threshold, k=None)
+    def test_no_k(self, datasets, threshold, f):
+        sims, indices = f(datasets, threshold, k=None)
         candidates = dict(zip(zip(indices[0], indices[1]), sims))
         
         _sanity_check_candidates(sims, indices, candidates)
@@ -69,7 +72,7 @@ class TestHammingSimilarity:
         for (i0, record0), (i1, record1) \
                 in itertools.product(enumerate(datasets[0]),
                                      enumerate(datasets[1])):
-            sim = _hamming_sim(record0, record1)
+            sim = _smc_sim(record0, record1)
 
             if sim >= threshold:
                 assert (i0, i1) in candidates
@@ -78,8 +81,8 @@ class TestHammingSimilarity:
                 assert (i0, i1) not in candidates
 
     @pytest.mark.parametrize('k', [0, 20, 80])
-    def test_k(self, datasets, threshold, k):
-        sims, indices = hamming_similarity(datasets, threshold, k=k)
+    def test_k(self, datasets, threshold, k, f):
+        sims, indices = f(datasets, threshold, k=k)
         candidates = dict(zip(zip(indices[0], indices[1]), sims))
         
         _sanity_check_candidates(sims, indices, candidates)
@@ -92,7 +95,7 @@ class TestHammingSimilarity:
 
         for (i0, record0), (i1, record1) \
                 in itertools.product(*map(enumerate, datasets)):
-            sim = _hamming_sim(record0, record1)
+            sim = _smc_sim(record0, record1)
 
             if sim >= threshold:
                 if (i0, i1) not in candidates:
@@ -108,10 +111,12 @@ class TestHammingSimilarity:
             else:
                 assert (i0, i1) not in candidates
 
+
 @pytest.mark.parametrize('size', [0, 1, 3, 5])
 @pytest.mark.parametrize('threshold', [0., .5, 1.])
 @pytest.mark.parametrize('k', [None, 0, 10])
-def test_unsupported_size(size, threshold, k):
+@pytest.mark.parametrize('f', SIM_FUNS)
+def test_unsupported_size(size, threshold, k, f):
     datasets = [['01001101'] for _ in range(size)]
     with pytest.raises(NotImplementedError):
-        hamming_similarity(datasets, threshold, k=k)
+        f(datasets, threshold, k=k)


### PR DESCRIPTION
Rename `anonlink.similarities.hamming_similarity` to `anonlink.similarities.simple_matching_coefficient`. Closes #161.

`similarities.hamming_similarity` remains as a deprecated alias.