### PR TITLE
Import similarities in __init__

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ install:
   - travis_retry pip install -e .
 
 script:
-  - pytest --cov=anonlink -W ignore:DeprecationWarning
+  - pytest --cov=anonlink -W ignore::DeprecationWarning

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -45,7 +45,7 @@ def build(python_version, compiler, label, release = false) {
 
     PythonVirtualEnvironment venv = prepareVirtualEnvironment(python_version, clkhashPackageName, compiler)
     try {
-      venv.runChosenCommand("pytest --cov=anonlink --junit-xml=testoutput.xml --cov-report=xml:coverage.xml -W ignore:DeprecationWarning")
+      venv.runChosenCommand("pytest --cov=anonlink --junit-xml=testoutput.xml --cov-report=xml:coverage.xml -W ignore::DeprecationWarning")
       if (release) {
         // This will be the official release
         archiveArtifacts artifacts: "dist/anonlink-*.whl"

--- a/anonlink/__init__.py
+++ b/anonlink/__init__.py
@@ -7,6 +7,7 @@ from anonlink import concurrency
 from anonlink import entitymatch
 from anonlink import network_flow
 from anonlink import serialization
+from anonlink import similarities
 from anonlink import solving
 from anonlink import typechecking
 

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -18,4 +18,4 @@ done
 
 # Install packages and test
 "${PYBIN}/pip" install anonlink --no-index -f /io/wheelhouse
-(cd "$HOME"; "${PYBIN}/pytest" /io/tests -W ignore:DeprecationWarning)
+(cd "$HOME"; "${PYBIN}/pytest" /io/tests -W ignore::DeprecationWarning)


### PR DESCRIPTION
Fixes issue where `anonlink` and `anonlink.similarities` have to be imported separately:
```python
import anonlink
import anonlink.similarities
```

`anonlink.similarities` is now imported whenever `anonlink` is imported.