### PR TITLE
Support bytes in Dice coefficient functions

### DIFF
--- a/anonlink/similarities/_dice_python.py
+++ b/anonlink/similarities/_dice_python.py
@@ -5,7 +5,8 @@ from typing import Optional, Sequence, Tuple
 
 from bitarray import bitarray
 
-from anonlink.similarities._utils import sort_similarities_inplace
+from anonlink.similarities._utils import (sort_similarities_inplace,
+                                          to_bitarrays)
 from anonlink.typechecking import FloatArrayType, IntArrayType
 
 __all__ = ['dice_coefficient_python']
@@ -45,6 +46,8 @@ def dice_coefficient_python(
         raise NotImplementedError(
             f'too many datasets (expected 2, got {n_datasets})')
     filters0, filters1 = datasets
+    filters0 = to_bitarrays(filters0)
+    filters1 = to_bitarrays(filters1)
 
     result_sims: FloatArrayType = array('d')
     result_indices0: IntArrayType = array('I')

--- a/anonlink/similarities/_dice_x86.py
+++ b/anonlink/similarities/_dice_x86.py
@@ -6,7 +6,8 @@ from typing import Optional, Sequence, Tuple
 from bitarray import bitarray
 
 from anonlink._entitymatcher import ffi, lib
-from anonlink.similarities._utils import sort_similarities_inplace
+from anonlink.similarities._utils import (sort_similarities_inplace,
+                                          to_bitarrays)
 from anonlink.typechecking import FloatArrayType, IntArrayType
 
 __all__ = ['dice_coefficient_accelerated']
@@ -55,6 +56,8 @@ def dice_coefficient_accelerated(
         raise NotImplementedError(
             f'too many datasets (expected 2, got {n_datasets})')
     filters0, filters1 = datasets
+    filters0 = to_bitarrays(filters0)
+    filters1 = to_bitarrays(filters1)
 
     result_sims: FloatArrayType = array('d')
     result_indices0: IntArrayType = array('I')
@@ -76,8 +79,9 @@ def dice_coefficient_accelerated(
         raise ValueError('inconsistent filter length')
     filter_bits = len(filters0[0])
     if filter_bits % 64:
-        msg = (f'only filters whose length is a multiple of 64 are currently '
-               f'supported (got filter with length ({filter_bits})')
+        msg = (f'only filters whose length in bits is a multiple of 64 '
+               f'are currently supported (got filter with length '
+               f'{filter_bits})')
         raise NotImplementedError(msg)
     filter_bytes = filter_bits // 8
 

--- a/anonlink/similarities/_utils.py
+++ b/anonlink/similarities/_utils.py
@@ -1,3 +1,4 @@
+from bitarray import bitarray
 import numpy as np
 
 from anonlink.typechecking import FloatArrayType, IntArrayType
@@ -21,3 +22,24 @@ def sort_similarities_inplace(
     np_sims[:] = np_sims[order]
     np_indices0[:] = np_indices0[order]
     np_indices1[:] = np_indices1[order]
+
+
+def to_bitarray(record) -> bitarray:
+    if isinstance(record, bitarray):
+        return record
+    if not isinstance(record, bytes):
+        try:  # Not bitarray, not bytes. But is it bytes-like?
+            record = bytes(record)
+        except TypeError:
+            raise TypeError('unsupported record type') from None
+    ba = bitarray()
+    ba.frombytes(record)
+    return ba
+
+
+def to_bitarrays(records):
+    if all(isinstance(record, bitarray) for record in records):
+        return records
+    else:
+        return tuple(map(to_bitarray, records))
+

--- a/tests/test_similarity_dice.py
+++ b/tests/test_similarity_dice.py
@@ -226,7 +226,7 @@ class TestBloomFilterComparison:
 
         datasets = [[bitarray('01001011') * 8], []]
         sims, (rec_is0, rec_is1) = sim_fun(datasets, threshold, k=k) 
-        assert len(sims) == len(rec_is0) == len(rec_is1) == 0#
+        assert len(sims) == len(rec_is0) == len(rec_is1) == 0
         assert sims.typecode in FLOAT_ARRAY_TYPES
         assert (rec_is0.typecode in UINT_ARRAY_TYPES
                 and rec_is1.typecode in UINT_ARRAY_TYPES)


### PR DESCRIPTION
We should be supporting datasets of `bytes` in the Dice coefficient functions in addition to `bitarray`.

This is a quick and dirty hack for now, since the code needs refactoring in Cython anyway. We convert all records to `bitarray` at the start if they are not `bitarray`s already.