### PR TITLE
Add probabilistic greedy solver

### DIFF
--- a/anonlink/solving/__init__.py
+++ b/anonlink/solving/__init__.py
@@ -9,13 +9,17 @@ import typing as _typing
 
 import anonlink.typechecking as _typechecking
 
-from anonlink.solving._multiparty_solving_python import greedy_solve_python
+from anonlink.solving._multiparty_solving_python import (
+    greedy_solve_python, probabilistic_greedy_solve_python)
 try:
-    from anonlink.solving._multiparty_solving import greedy_solve_native
+    from anonlink.solving._multiparty_solving import (
+        greedy_solve_native, probabilistic_greedy_solve_native)
 except ImportError:
     greedy_solve = greedy_solve_python
+    probabilistic_greedy_solve = probabilistic_greedy_solve_python
 else:
     greedy_solve = greedy_solve_native
+    probabilistic_greedy_solve = probabilistic_greedy_solve_native
 
 
 def pairs_from_groups(

--- a/anonlink/solving/_multiparty_solving.pyi
+++ b/anonlink/solving/_multiparty_solving.pyi
@@ -1,4 +1,8 @@
 import anonlink.typechecking as _typechecking
 
-
 def greedy_solve_native(candidates: _typechecking.CandidatePairs) -> _typechecking.MatchGroups: ...
+def probabilistic_greedy_solve_native(
+    candidates: _typechecking.CandidatePairs,
+    *,
+    merge_threshold: float = ...,
+    deduplicated: bool = ...) -> _typechecking.MatchGroups: ...

--- a/anonlink/solving/_multiparty_solving.pyx
+++ b/anonlink/solving/_multiparty_solving.pyx
@@ -1,3 +1,4 @@
+from libcpp cimport bool
 from libcpp.vector cimport vector
 
 from cython.operator cimport dereference as deref
@@ -6,27 +7,62 @@ from anonlink.solving._multiparty_solving_inner cimport (
     Record, Group, greedy_solve_inner)
 
 
-def greedy_solve_native(candidates):
-    """Select matches from candidate pairs using the greedy algorithm.
+def probabilistic_greedy_solve_native(
+    candidates,
+    *,
+    merge_threshold=.5,
+    deduplicated=True
+):
+    """Select matches using the probabilistic greedy algorithm.
+
+    This solver is similar to `greedy_solve_native`, but may match
+    records that do not have corresponding candidate pairs when there is
+    enough other evidence that they are a match. This usually results in
+    better accuracy.
 
     We assign each record to exactly one 'group' of records that are
     pairwise matched together. We iterate over `candidates` in order of
     decreasing similarity. When we encounter a pair of records (let s be
     their similarity) that do not already belong to the same group, we
-    merge their groups iff (a) every pair of records is permitted to be
-    matched, and (b) the similarity of every pair of records is above s.
-    The latter requirement is only for tie-breaking: we prefer groups
-    whose minimum pairwise similarity is highest. Any group merge
-    rejected due to requirement (b) will be revisited later with that
-    requirement relaxed.
+    merge their groups iff (a) the proportion of pairs that are
+    permitted to be matched in the groups' records is at least
+    `merge_threshold`, and (b) the proportion of pairs whose similarity
+    is above s in the groups' records is at least `merge_threshold`. The
+    latter requirement is only for tie-breaking: we prefer groups whose
+    minimum pairwise similarity is highest. Any group merge rejected due
+    to requirement (b) will be revisited later with that requirement
+    relaxed.
 
     :param tuple candidates: Candidates, as returned by
         `find_candidates`.
+    :param float merge_threshold: Proportion of agreement between groups
+        required to merge them. In (0, 1].
+            When considering whether to merge two groups, we compute the
+        groups' Cartesian product. We count the pairs in that product
+        whose similarity is above the threshold. We merge the groups if
+        our count is at least `merge_threshold` of the total number of
+        pairs between the two groups.
+            For example, suppose that we have two groups of records: 
+        {A, B} and {C, D}. Let A-C, A-D and B-C be candidate pairs.
+        Setting `merge_threshold` to any value not greater than .75 will
+        permit the two groups to be merged since they share three
+        candidate pairs out of all four pairs. Even though the
+        similarity of B-D is below the threshold, there is enough
+        evidence in the other pairs to conclude that it must be a match.
+        The `merge_threshold` can be thought of as the inverse of the
+        weight we place on that evidence.
+            Higher values increase precision, but decrease recall.
+            A `merge_threshold` lower than one permits two records to be
+        matched without having a corresponding candidate pair. Set it to
+        1.0 to ensure that two records will only be matched if their
+        similarity is above the similarity threshold.
+    :param bool deduplicated: When True, two records that belong to the
+        same dataset will never be in the same group. Default True.
 
-    :return: An tuple of groups. Each group is an tuple of records. Two
-        records are in the same group iff they represent the same
-        entity. Here, a record is a two-tuple of dataset index and
-        record index.
+    :return: An sequence of groups. Each group is an sequence of
+        records. Two records are in the same group iff they represent
+        the same entity. Here, a record is a two-tuple of dataset index
+        and record index.
     """
     sims_arr, dset_is_arrs, rec_is_arrs = candidates
     if len(dset_is_arrs) != len(rec_is_arrs):
@@ -48,6 +84,9 @@ def greedy_solve_native(candidates):
     cdef unsigned int[::1] rec_is0 = rec_is0_arr
     cdef unsigned int[::1] rec_is1 = rec_is1_arr
 
+    cdef double merge_threshold_double = merge_threshold
+    cdef bool deduplicated_bool = deduplicated
+
     if n:
         with nogil:
             cpp_result = greedy_solve_inner(
@@ -55,7 +94,9 @@ def greedy_solve_native(candidates):
                 &dset_is1[0],
                 &rec_is0[0],
                 &rec_is1[0],
-                n)
+                n,
+                merge_threshold_double,
+                deduplicated_bool)
 
         # Save groups of size > 1.
         result = tuple(tuple((record.dset_i, record.rec_i)
@@ -67,3 +108,29 @@ def greedy_solve_native(candidates):
         return result
     else:
         return ()
+
+
+def greedy_solve_native(candidates):
+    """Select matches from candidate pairs using the greedy algorithm.
+
+    We assign each record to exactly one 'group' of records that are
+    pairwise matched together. We iterate over `candidates` in order of
+    decreasing similarity. When we encounter a pair of records (let s be
+    their similarity) that do not already belong to the same group, we
+    merge their groups iff (a) every pair of records is permitted to be
+    matched, and (b) the similarity of every pair of records is above s.
+    The latter requirement is only for tie-breaking: we prefer groups
+    whose minimum pairwise similarity is highest. Any group merge
+    rejected due to requirement (b) will be revisited later with that
+    requirement relaxed.
+
+    :param tuple candidates: Candidates, as returned by
+        `find_candidates`.
+
+    :return: An sequence of groups. Each group is an sequence of
+        records. Two records are in the same group iff they represent
+        the same entity. Here, a record is a two-tuple of dataset index
+        and record index.
+    """
+    return probabilistic_greedy_solve_native(
+        candidates, merge_threshold=1.0, deduplicated=False)

--- a/anonlink/solving/_multiparty_solving.pyx
+++ b/anonlink/solving/_multiparty_solving.pyx
@@ -87,7 +87,7 @@ def probabilistic_greedy_solve_native(
     cdef double merge_threshold_double = merge_threshold
     cdef bool deduplicated_bool = deduplicated
 
-    if n:
+    if n:  # Prevent dereferencing empty arrays.
         with nogil:
             cpp_result = greedy_solve_inner(
                 &dset_is0[0],

--- a/anonlink/solving/_multiparty_solving_inner.h
+++ b/anonlink/solving/_multiparty_solving_inner.h
@@ -23,6 +23,8 @@ greedy_solve_inner(
     unsigned int dset_is1[],
     unsigned int rec_is0[],
     unsigned int rec_is1[],
-    size_t n);
+    size_t n,
+    double merge_threshold,
+    bool deduplicated);
 
 #endif /* _multiparty_solving_inner_h */

--- a/anonlink/solving/_multiparty_solving_inner.h
+++ b/anonlink/solving/_multiparty_solving_inner.h
@@ -14,6 +14,10 @@ struct Record {
     }
 };
 
+
+// These are only ever made inside the GroupsStore class in _multiparty_solving_inner.
+// They are always created with at least one element. Elements are never deleted. Thus, they are
+// always nonempty.
 typedef std::vector<Record> Group;
 
 

--- a/anonlink/solving/_multiparty_solving_inner.pxd
+++ b/anonlink/solving/_multiparty_solving_inner.pxd
@@ -1,3 +1,4 @@
+from libcpp cimport bool
 from libcpp.vector cimport vector
 from libcpp.unordered_set cimport unordered_set
 
@@ -14,6 +15,8 @@ cdef extern from "_multiparty_solving_inner.h":
         unsigned int[],
         unsigned int[],
         unsigned int[],
-        size_t n
+        size_t,
+        double,
+        bool
     ) nogil except +
     # `except +` asks Cython to propagate C++ exceptions to Python land

--- a/anonlink/solving/_multiparty_solving_python.py
+++ b/anonlink/solving/_multiparty_solving_python.py
@@ -5,30 +5,67 @@ import typing as _typing
 import anonlink.typechecking as _typechecking
 
 
-def greedy_solve_python(
-    candidates: _typechecking.CandidatePairs
+def probabilistic_greedy_solve_python(
+    candidates: _typechecking.CandidatePairs,
+    *,
+    merge_threshold: float = .5,
+    deduplicated: bool = True
 ) -> _typechecking.MatchGroups:
-    """ Select matches from candidate pairs using the greedy algorithm.
+    """Select matches using the probabilistic greedy algorithm.
+
+    This solver is similar to `greedy_solve_native`, but may match
+    records that do not have corresponding candidate pairs when there is
+    enough other evidence that they are a match. This usually results in
+    better accuracy.
 
     We assign each record to exactly one 'group' of records that are
     pairwise matched together. We iterate over `candidates` in order of
     decreasing similarity. When we encounter a pair of records (let s be
     their similarity) that do not already belong to the same group, we
-    merge their groups iff (a) every pair of records is permitted to be
-    matched, and (b) the similarity of every pair of records is above s.
-    The latter requirement is only for tie-breaking: we prefer groups
-    whose minimum pairwise similarity is highest. Any group merge
-    rejected due to requirement (b) will be revisited later with that
-    requirement relaxed.
+    merge their groups iff (a) the proportion of pairs that are
+    permitted to be matched in the groups' records is at least
+    `merge_threshold`, and (b) the proportion of pairs whose similarity
+    is above s in the groups' records is at least `merge_threshold`. The
+    latter requirement is only for tie-breaking: we prefer groups whose
+    minimum pairwise similarity is highest. Any group merge rejected due
+    to requirement (b) will be revisited later with that requirement
+    relaxed.
 
     :param tuple candidates: Candidates, as returned by
         `find_candidates`.
+    :param float merge_threshold: Proportion of agreement between groups
+        required to merge them. In (0, 1].
+            When considering whether to merge two groups, we compute the
+        groups' Cartesian product. We count the pairs in that product
+        whose similarity is above the threshold. We merge the groups if
+        our count is at least `merge_threshold` of the total number of
+        pairs between the two groups.
+            For example, suppose that we have two groups of records: 
+        {A, B} and {C, D}. Let A-C, A-D and B-C be candidate pairs.
+        Setting `merge_threshold` to any value not greater than .75 will
+        permit the two groups to be merged since they share three
+        candidate pairs out of all four pairs. Even though the
+        similarity of B-D is below the threshold, there is enough
+        evidence in the other pairs to conclude that it must be a match.
+        The `merge_threshold` can be thought of as the inverse of the
+        weight we place on that evidence.
+            Higher values increase precision, but decrease recall.
+            A `merge_threshold` lower than one permits two records to be
+        matched without having a corresponding candidate pair. Set it to
+        1.0 to ensure that two records will only be matched if their
+        similarity is above the similarity threshold.
+    :param bool deduplicated: When True, two records that belong to the
+        same dataset will never be in the same group. Default True.
 
-    :return: An iterable of groups. Each group is an iterable of
+    :return: An sequence of groups. Each group is an sequence of
         records. Two records are in the same group iff they represent
         the same entity. Here, a record is a two-tuple of dataset index
         and record index.
     """
+    if merge_threshold < 0 or merge_threshold > 1:
+        raise ValueError(
+            f'merge_threshold must be between 0 and 1 (got {merge_threshold})') 
+
     sims, dset_is, rec_is = candidates
     if len(dset_is) != len(rec_is):
         raise ValueError('inconsistent shape of index arrays')
@@ -79,8 +116,12 @@ def greedy_solve_python(
             # of pairs is len(i0_matches) * len(i1_matches)). When this
             # is the number of matchable pairs, then every pair is
             # matchable.
-            if (matchable_pairs[i0_mid][i1_mid] + 1
-                == len(i0_matches) * len(i1_matches)):
+            agreement = ((matchable_pairs[i0_mid][i1_mid] + 1)
+                         / (len(i0_matches) * len(i1_matches)))
+            duplicates_ok = (not deduplicated or all(m0 != m1
+                                                     for m0, _ in i0_matches
+                                                     for m1, _ in i1_matches))
+            if agreement >= merge_threshold and duplicates_ok:
                 # Optimise by always extending the bigger group.
                 if len(i0_matches) < len(i1_matches):
                     i0, i1 = i1, i0
@@ -114,7 +155,10 @@ def greedy_solve_python(
             # i0 is in a group, but i1 is not.
             # See if we may assign i0 to that group.
             i0_matches = matches[i0]
-            if len(i0_matches) == 1:
+            agreement = 1 / len(i0_matches)
+            duplicates_ok = not deduplicated or all(m0 != i1[0]
+                                                    for m0, _ in i0_matches)
+            if agreement >= merge_threshold and duplicates_ok:
                 # i0 is a group of 1, so trivially we can merge.
                 i0_matches.append(i1)
                 matches[i1] = i0_matches
@@ -130,8 +174,10 @@ def greedy_solve_python(
             continue
 
         if i0 not in matches and i1 not in matches:
-            # Neither is in a group, so let's just make one.
-            matches[i0] = matches[i1] = [i0, i1]
+            duplicates_ok = not deduplicated or i0[0] != i1[0]
+            if duplicates_ok:
+                # Neither is in a group, so let's just make one.
+                matches[i0] = matches[i1] = [i0, i1]
             continue
 
         raise RuntimeError('non-exhaustive cases')
@@ -141,3 +187,31 @@ def greedy_solve_python(
                            for group in matches.values()
                            if len(group) > 1}
     return tuple(map(tuple, deduplicated_groups.values()))
+
+
+def greedy_solve_python(
+    candidates: _typechecking.CandidatePairs
+) -> _typechecking.MatchGroups:
+    """Select matches from candidate pairs using the greedy algorithm.
+
+    We assign each record to exactly one 'group' of records that are
+    pairwise matched together. We iterate over `candidates` in order of
+    decreasing similarity. When we encounter a pair of records (let s be
+    their similarity) that do not already belong to the same group, we
+    merge their groups iff (a) every pair of records is permitted to be
+    matched, and (b) the similarity of every pair of records is above s.
+    The latter requirement is only for tie-breaking: we prefer groups
+    whose minimum pairwise similarity is highest. Any group merge
+    rejected due to requirement (b) will be revisited later with that
+    requirement relaxed.
+
+    :param tuple candidates: Candidates, as returned by
+        `find_candidates`.
+
+    :return: An sequence of groups. Each group is an sequence of
+        records. Two records are in the same group iff they represent
+        the same entity. Here, a record is a two-tuple of dataset index
+        and record index.
+    """
+    return probabilistic_greedy_solve_python(
+        candidates, merge_threshold=1.0, deduplicated=False)

--- a/anonlink/solving/_multiparty_solving_python.py
+++ b/anonlink/solving/_multiparty_solving_python.py
@@ -116,12 +116,12 @@ def probabilistic_greedy_solve_python(
             # of pairs is len(i0_matches) * len(i1_matches)). When this
             # is the number of matchable pairs, then every pair is
             # matchable.
-            agreement = ((matchable_pairs[i0_mid][i1_mid] + 1)
-                         / (len(i0_matches) * len(i1_matches)))
+            overlap = matchable_pairs[i0_mid][i1_mid] + 1
+            total_pairs = len(i0_matches) * len(i1_matches)
             duplicates_ok = (not deduplicated or all(m0 != m1
                                                      for m0, _ in i0_matches
                                                      for m1, _ in i1_matches))
-            if agreement >= merge_threshold and duplicates_ok:
+            if overlap >= merge_threshold * total_pairs and duplicates_ok:
                 # Optimise by always extending the bigger group.
                 if len(i0_matches) < len(i1_matches):
                     i0, i1 = i1, i0
@@ -155,10 +155,11 @@ def probabilistic_greedy_solve_python(
             # i0 is in a group, but i1 is not.
             # See if we may assign i0 to that group.
             i0_matches = matches[i0]
-            agreement = 1 / len(i0_matches)
+            overlap = 1
+            total_pairs = len(i0_matches)
             duplicates_ok = not deduplicated or all(m0 != i1[0]
                                                     for m0, _ in i0_matches)
-            if agreement >= merge_threshold and duplicates_ok:
+            if overlap >= merge_threshold * total_pairs and duplicates_ok:
                 # i0 is a group of 1, so trivially we can merge.
                 i0_matches.append(i1)
                 matches[i1] = i0_matches

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -5,8 +5,10 @@ from collections import Counter
 import pytest
 from hypothesis import given, reject, strategies
 
-from anonlink.solving import (greedy_solve, greedy_solve_python,
-                              greedy_solve_native, pairs_from_groups)
+from anonlink.solving import (
+    greedy_solve, greedy_solve_python, greedy_solve_native, pairs_from_groups,
+    probabilistic_greedy_solve, probabilistic_greedy_solve_native,
+    probabilistic_greedy_solve_python)
 
 def _zip_candidates(candidates):
     candidates = tuple(candidates)
@@ -196,6 +198,14 @@ candidate_pairs_np = strategies.dictionaries(
         strategies.floats(min_value=0, max_value=1)
     ).map(dict_to_candidate_pairs)
 
+index_pair_np_ndedup = strategies.tuples(
+        indices_np, indices_np
+    ).map(lambda x: tuple(sorted(x)))
+candidate_pairs_np_ndedup = strategies.dictionaries(
+        index_pair_np,
+        strategies.floats(min_value=0, max_value=1)
+    ).map(dict_to_candidate_pairs)
+
 @given(candidate_pairs_np)
 def test_greedy_np(candidate_pairs):
     candidates = _zip_candidates(candidate_pairs)
@@ -298,3 +308,136 @@ def _groups_from_pairs(pairs):
 @given(groups_space_2p)
 def test_pairs_from_groups(groups):
     assert groups == _groups_from_pairs(pairs_from_groups(groups))
+
+
+@given(candidate_pairs_2p,
+       strategies.floats(min_value=0, max_value=1),
+       strategies.booleans())
+def test_probabilistic_python_native_match_2p(
+    candidate_pairs,
+    merge_threshold,
+    deduplicated
+):
+    candidates = _zip_candidates(candidate_pairs)
+    solution_python = probabilistic_greedy_solve_python(
+        candidates, merge_threshold=merge_threshold, deduplicated=deduplicated)
+    solution_native = probabilistic_greedy_solve_native(
+        candidates, merge_threshold=merge_threshold, deduplicated=deduplicated)
+
+    # We don't care about the order
+    solution_python = frozenset(map(frozenset, solution_python))
+    solution_native = frozenset(map(frozenset, solution_native))
+
+    assert solution_python == solution_native
+
+
+@given(candidate_pairs_np,
+       strategies.floats(min_value=0, max_value=1),
+       strategies.booleans())
+def test_probabilistic_python_native_match_np(
+    candidate_pairs,
+    merge_threshold,
+    deduplicated
+):
+    candidates = _zip_candidates(candidate_pairs)
+    solution_python = probabilistic_greedy_solve_python(
+        candidates, merge_threshold=merge_threshold, deduplicated=deduplicated)
+    solution_native = probabilistic_greedy_solve_native(
+        candidates, merge_threshold=merge_threshold, deduplicated=deduplicated)
+
+    # We don't care about the order
+    solution_python = frozenset(map(frozenset, solution_python))
+    solution_native = frozenset(map(frozenset, solution_native))
+
+    assert solution_python == solution_native
+
+
+@given(candidate_pairs_np_ndedup,
+       strategies.floats(min_value=0, max_value=1),
+       strategies.booleans())
+def test_probabilistic_python_native_match_np_ndedup(
+    candidate_pairs,
+    merge_threshold,
+    deduplicated
+):
+    candidates = _zip_candidates(candidate_pairs)
+    solution_python = probabilistic_greedy_solve_python(
+        candidates, merge_threshold=merge_threshold, deduplicated=deduplicated)
+    solution_native = probabilistic_greedy_solve_native(
+        candidates, merge_threshold=merge_threshold, deduplicated=deduplicated)
+
+    # We don't care about the order
+    solution_python = frozenset(map(frozenset, solution_python))
+    solution_native = frozenset(map(frozenset, solution_native))
+
+    assert solution_python == solution_native
+
+
+@given(candidate_pairs_np)
+def test_probabilistic_nonprobabilistic_match(candidate_pairs):
+    candidates = _zip_candidates(candidate_pairs)
+    solution_probabilistic = probabilistic_greedy_solve(
+        candidates, merge_threshold=1, deduplicated=False)
+    solution_nonprobabilistic = greedy_solve(candidates)
+
+    # We don't care about the order
+    solution_probabilistic = frozenset(map(frozenset, solution_probabilistic))
+    solution_nonprobabilistic = frozenset(map(frozenset,
+                                              solution_nonprobabilistic))
+
+    assert solution_probabilistic == solution_nonprobabilistic
+
+
+@given(candidate_pairs_np_ndedup)
+def test_probabilistic_nonprobabilistic_match_ndedup(candidate_pairs):
+    candidates = _zip_candidates(candidate_pairs)
+    solution_probabilistic = probabilistic_greedy_solve(
+        candidates, merge_threshold=1, deduplicated=False)
+    solution_nonprobabilistic = greedy_solve(candidates)
+
+    # We don't care about the order
+    solution_probabilistic = frozenset(map(frozenset, solution_probabilistic))
+    solution_nonprobabilistic = frozenset(map(frozenset,
+                                              solution_nonprobabilistic))
+
+    assert solution_probabilistic == solution_nonprobabilistic
+
+
+def test_probabilistic_greedy():
+    candidates = [(.9, ((0, 0), (0, 1))),
+                  (.8, ((1, 0), (1, 1))),
+                  (.7, ((0, 0), (1, 0))),
+                  (.6, ((0, 0), (1, 1))),
+                  (.5, ((0, 1), (1, 0)))]
+    
+    result = probabilistic_greedy_solve(
+        _zip_candidates(candidates), merge_threshold=0., deduplicated=True)
+    _compare_matching(result, [{(0,0), (1,0)}])
+    
+    result = probabilistic_greedy_solve(
+        _zip_candidates(candidates), merge_threshold=.75, deduplicated=True)
+    _compare_matching(result, [{(0,0), (1,0)}])
+    
+    result = probabilistic_greedy_solve(
+        _zip_candidates(candidates), merge_threshold=.76, deduplicated=True)
+    _compare_matching(result, [{(0,0), (1,0)}])
+    
+    result = probabilistic_greedy_solve(
+        _zip_candidates(candidates), merge_threshold=1., deduplicated=True)
+    _compare_matching(result, [{(0,0), (1,0)}])
+    
+    result = probabilistic_greedy_solve(
+        _zip_candidates(candidates), merge_threshold=0.0, deduplicated=False)
+    _compare_matching(result, [{(0,0), (1,0), (0,1), (1,1)}])
+    
+    result = probabilistic_greedy_solve(
+        _zip_candidates(candidates), merge_threshold=0.75, deduplicated=False)
+    _compare_matching(result, [{(0,0), (1,0), (0,1), (1,1)}])
+    
+    result = probabilistic_greedy_solve(
+        _zip_candidates(candidates), merge_threshold=0.76, deduplicated=False)
+    _compare_matching(result, [{(0,0), (0,1)}, {(1,0), (1,1)}])
+    
+    result = probabilistic_greedy_solve(
+        _zip_candidates(candidates), merge_threshold=1, deduplicated=False)
+    _compare_matching(result, [{(0,0), (0,1)}, {(1,0), (1,1)}])


### PR DESCRIPTION
This usually performs better than the old greedy. It can get more information from having multiple datasets. If we have datasets A, B, and C, we get more information about links between A and B by looking at A-C and B-C.

As before, we assign each record to a group. We iterate through the candidate pairs in decreasing order of similarity and merge the records’ corresponding groups. Previously, we only merged groups if all the pairs between the groups have been encountered. Now we merge them if we have encountered a particular fraction (`merge_threshold`) of the pairs between the groups. This results in better accuracy.

![solver-comparison](https://user-images.githubusercontent.com/12507513/48341874-5fcb4100-e6c2-11e8-9bdd-7433c7dd6ed1.png)

An implication of this change is that we may produce matched pairs that are not in the given candidate pairs. This is fine, as long as we do not match records in the same dataset. This is because we usually assume datasets to be deduplicated. Hence, we make sure that the elements of two groups all come from different datasets before we merge those groups. (There is a `deduplicated` flag, which can disable this check.)

`_multiparty_solving_inner.cpp` contains most of the changes to the C++ code and `_multiparty_solving.pyx` is the glue code. There are some auxiliary changes in `_multiparty_solving_inner.h`, `_multiparty_solving_inner.pxd`, and `_multiparty_solving.pyi`. `_multiparty_solving_python.py` introduces the same changes to the Python version of the solver.