### PR TITLE
Fix stream buffering with Minio

### DIFF
--- a/anonlink/serialization.py
+++ b/anonlink/serialization.py
@@ -120,10 +120,10 @@ def _make_buffered(
     f: _typing.BinaryIO
 ) -> _typing.BinaryIO:
     # Make sure that f.read(n) returns exactly n bytes.
-    if not isinstance(f, _io.BufferedIOBase):
-        f = _io.BufferedReader(f)  # type: ignore
-        # Mypy complains that f is not guaranteed to be RawIOBase.
-        # That's true but BufferedReader doesn't explicitly check this.
+    if isinstance(f, _io.RawIOBase):
+        f = _io.BufferedReader(f)
+    # If f is neither BufferedReader nor RawIOBase then we shrug and see
+    # what happens...
     return f
 
 


### PR DESCRIPTION
This fixes the deserialisation code when it is given a Minio file. I don’t know why it fixes it.

It just does. 🤷🏼‍♂️

(It also needs to be followed by a release because otherwise the tests in n1analytics/entity-service#339 won’t pass.)