### PR TITLE
Have travis make the pypi release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,41 @@
 language: python
 sudo: false
-
 python:
-  - '3.7-dev'
-  - 'nightly'
-  - 'pypy3'
-
+- 3.7-dev
+- nightly
+- pypy3
 env:
-  - INCLUDE_10K=
-
+- INCLUDE_10K=
 matrix:
   allow_failures:
-    - python: '3.7-dev'
-    - python: 'nightly'
-    - python: 'pypy3'
-
+  - python: 3.7-dev
+  - python: nightly
+  - python: pypy3
   include:
-    - python: '3.6'
-      env:
-        - MYPY_TYPING=1
-
+  - python: '3.6'
+    env:
+    - MYPY_TYPING=1
 jobs:
   include:
-    - stage: Build wheels
-      sudo: required
-      python: '3.6'
-      services:
-        - docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
-      install: docker pull $DOCKER_IMAGE
-      script:
-        - docker run --rm -v `pwd`:/io $DOCKER_IMAGE /io/travis/build-wheels.sh
-        - ls wheelhouse/
+  - stage: Build wheels
+    sudo: required
+    python: '3.6'
+    services:
+    - docker
+    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+    install: docker pull $DOCKER_IMAGE
+    script:
+    - docker run --rm -v `pwd`:/io $DOCKER_IMAGE /io/travis/build-wheels.sh
+    - ls wheelhouse/
 
 install:
-  - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install mypy; fi
-  - travis_retry pip install pytest pytest-cov
-  - if [ -n "$USE_ASV" ]; then pip install asv; fi
-  - travis_retry pip install -r requirements.txt
-  - travis_retry python setup.py sdist bdist_wheel
-  - travis_retry pip install -e .
-
+- if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install mypy; fi
+- travis_retry pip install pytest pytest-cov
+- if [ -n "$USE_ASV" ]; then pip install asv; fi
+- travis_retry pip install -r requirements.txt
+- travis_retry python setup.py sdist bdist_wheel
+- travis_retry pip install -e .
 script:
-  - if [ "${MYPY_TYPING}" == "1" ]; then mypy anonlink --ignore-missing-imports; fi
-  - pytest --cov=anonlink -W ignore::DeprecationWarning
+- if [ "${MYPY_TYPING}" == "1" ]; then mypy anonlink --ignore-missing-imports; fi
+- pytest --cov=anonlink -W ignore::DeprecationWarning
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,13 @@ jobs:
     script:
     - docker run --rm -v `pwd`:/io $DOCKER_IMAGE /io/travis/build-wheels.sh
     - ls wheelhouse/
+    deploy:
+      provider: pypi
+      user: confidentialcomputing
+      password:
+        secure: rRlPkjKaI/HIkA/HEagWgFyqZ6ds+yZWiYAsGHuop3DAGFKRjtDkvj+ukCoL0Tmz66PxyKp0wEEstA+RwdbkMkOPHGs7zraoRevETI2nrbmNLyipSlXrPIfm8Tru5mMQVMVXuKYfJwu4SnWZzd/Yd+E1wiLRU4IcACTyt1w9aSrDN122+Xgvq8/b9sJNp1VMaD/3ca4xBjuYlCH6FITjH1NCWL5ETguupoKF2kzXztSnO5jZhSfeGNe4yDoOymOKInaVy4Wog5HX0SbHAEuC13PxZn5HftSR4kwtuO0WZLZKX1qap6Vo06aQ9x+epR2ZtAdS0eHp/DaONSyCaKj9/bxYlSc45a2wnM4SgG0fX8MhCt2qHGnntXVcb60y3guEwb/uiI7yPAoG7sHcqdRCLLPYMzrKKmde83ElF29LMOf6MDfnfR+O1F1PDXZfzSi/bKUo42J6XrH8i5eDIRgS6kIGNncO4QoU7RHW+KoUPIZE9NfnPVkYNmc8m8O3Er5UF4OeIc/1SRouhq1hdb3VvahnXRWmHo1EYMYeKcVE6HVwkopnwWbs788ANl/lj8QlNY5jfPxWcEAqrhl9UfgFwgz7RAbYs04asqf3RvqX3NabfoeqtLzXMrq7ajdOMJuDhS7ody5aHzXj7rP/9K8Rju7qKeuVIf4VqJ1iKz2n1Q8=
+      on:
+        tags: true
 
 install:
 - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install mypy; fi


### PR DESCRIPTION
This change enables travis-ci to publish the manylinux built binaries to pypi.

It uses an encrypted secret, and should only deploy tagged commits. 
Addresses #75 
See docs https://docs.travis-ci.com/user/deployment/pypi/